### PR TITLE
Deploy Calibre-Web-Automated for Kobo library sync

### DIFF
--- a/infrastructure/cloudflare/opentofu/variables.tf
+++ b/infrastructure/cloudflare/opentofu/variables.tf
@@ -37,6 +37,7 @@ variable "tunnel_hostnames" {
   description = "Subdomains routed through the Pangolin tunnel on the Hetzner edge proxy"
   type        = set(string)
   default = [
+    "books-sync",
     "gimme",
     "mattflix",
     "pangolin",

--- a/infrastructure/tunnel/blueprints/books-sync.yaml
+++ b/infrastructure/tunnel/blueprints/books-sync.yaml
@@ -1,0 +1,24 @@
+# Kobo device sync only (see services/downloads-standard/calibre-web-
+# automated/README.md and issue #17). No SSO: a Kobo can't complete an
+# SSO redirect or hold a session cookie, and the k8s ingress
+# (ingress-books-sync.yaml) already restricts this host to the /kobo/
+# path prefix, so there's nothing else behind it worth gating - auth is
+# the per-user token embedded in the sync URL itself, checked by CWA.
+#
+# Rate limiting on /kobo/ (the one thing not covered by SSO on other
+# resources) isn't expressible in the Blueprint schema - no rate-limit
+# rule action exists alongside allow/deny/pass. Apply it manually in the
+# dashboard if wanted; it won't be clobbered by future blueprint applies
+# since applies only touch the fields specified here.
+public-resources:
+  books-sync:
+    name: "Books Sync"
+    mode: http
+    full-domain: books-sync.labmatt.com
+    targets:
+      - site: faithful-brachyurophis-fasciolatus
+        method: http
+        hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
+        port: 80
+    auth:
+      sso-enabled: false

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -4,11 +4,6 @@ Ebook library + Kobo device sync. See GitHub issue #17 for the full design
 (two-hostname split: `books.labmatt.com` tailnet-only admin UI,
 `books-sync.labmatt.com` path-restricted Kobo sync via Pangolin).
 
-DNS (`infrastructure/cloudflare/opentofu`) and the Pangolin Resource
-(`infrastructure/tunnel/blueprints/books-sync.yaml`) for
-`books-sync.labmatt.com` are handled in their own directories - see those
-for the apply steps. Once those are applied:
-
 1. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
    the per-user sync token/URL.
 2. On the Kobo device, point it at

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -15,7 +15,11 @@ kubectl apply -f .
 cd ../../../infrastructure/cloudflare/opentofu && tofu apply
 ```
 2. In the Pangolin dashboard, add `books-sync.labmatt.com` as a Resource
-   pointing at the Newt site / `calibre-web-automated` service, port 8083.
+   pointing at the Newt site / `ingress-nginx` LoadBalancer, port 80 - same
+   as `mattflix.labmatt.com` (see `jellyfin/ingress-block-metrics.yaml`).
+   Pointing it at the `calibre-web-automated` service directly would
+   bypass `ingress-books-sync.yaml`'s `/kobo/`-only path restriction and
+   expose the full admin UI on this host.
 3. Still in Pangolin, add two rules on `books-sync.labmatt.com`, scoped to
    path `/kobo/` (mirrors the existing `/metrics` block-path rule,
    inverted):

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -4,29 +4,28 @@ Ebook library + Kobo device sync. See GitHub issue #17 for the full design
 (two-hostname split: `books.labmatt.com` tailnet-only admin UI,
 `books-sync.labmatt.com` path-restricted Kobo sync via Pangolin).
 
-The manifests here handle the Kubernetes/DNS side; the following steps are
-manual (Pangolin has no config-as-code yet, see
-`infrastructure/tunnel/README.md`):
+The manifests here are Flux-managed (`services/downloads-standard/
+kustomization.yaml`) - merging to `main` deploys them, no manual
+`kubectl apply` needed. Two steps stay manual:
 
-1. Apply the manifests and `tofu apply` in `infrastructure/cloudflare/opentofu`
-   to create the `books-sync` DNS record:
+1. `tofu apply` in `infrastructure/cloudflare/opentofu` to create the
+   `books-sync` DNS record (already added to `tunnel_hostnames`):
 ```bash
-kubectl apply -f .
-cd ../../../infrastructure/cloudflare/opentofu && tofu apply
+cd infrastructure/cloudflare/opentofu && tofu apply
 ```
-2. In the Pangolin dashboard, add `books-sync.labmatt.com` as a Resource
-   pointing at the Newt site / `ingress-nginx` LoadBalancer, port 80 - same
-   as `mattflix.labmatt.com` (see `jellyfin/ingress-block-metrics.yaml`).
-   Pointing it at the `calibre-web-automated` service directly would
-   bypass `ingress-books-sync.yaml`'s `/kobo/`-only path restriction and
-   expose the full admin UI on this host.
-3. Still in Pangolin, add two rules on `books-sync.labmatt.com`, scoped to
-   path `/kobo/` (mirrors the existing `/metrics` block-path rule,
-   inverted):
-   - "Bypass Auth" - a Kobo can't complete an SSO redirect or hold a
-     session cookie.
-   - Rate limit - this path is the one thing not covered by SSO.
-4. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
+2. Apply `infrastructure/tunnel/blueprints/books-sync.yaml` via the
+   Pangolin dashboard's Settings > Blueprints page - see that
+   directory's README for the full workflow. It points
+   `books-sync.labmatt.com` at the `ingress-nginx` LoadBalancer (port
+   80), same as `mattflix.labmatt.com` - **not** directly at the
+   `calibre-web-automated` Service, which would bypass
+   `ingress-books-sync.yaml`'s `/kobo/`-only path restriction and expose
+   the full admin UI on this host. SSO is deliberately off for this
+   resource (a Kobo can't complete an SSO redirect); optionally add a
+   rate-limit rule on `/kobo/` by hand in the dashboard afterward - not
+   expressible in the Blueprint schema, see the blueprint file's own
+   comment.
+3. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
    the per-user sync token/URL.
-5. On the Kobo device, point it at
+4. On the Kobo device, point it at
    `https://books-sync.labmatt.com/kobo/<token>/`.

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -1,0 +1,28 @@
+# calibre-web-automated
+
+Ebook library + Kobo device sync. See GitHub issue #17 for the full design
+(two-hostname split: `books.labmatt.com` tailnet-only admin UI,
+`books-sync.labmatt.com` path-restricted Kobo sync via Pangolin).
+
+The manifests here handle the Kubernetes/DNS side; the following steps are
+manual (Pangolin has no config-as-code yet, see
+`infrastructure/tunnel/README.md`):
+
+1. Apply the manifests and `tofu apply` in `infrastructure/cloudflare/opentofu`
+   to create the `books-sync` DNS record:
+```bash
+kubectl apply -f .
+cd ../../../infrastructure/cloudflare/opentofu && tofu apply
+```
+2. In the Pangolin dashboard, add `books-sync.labmatt.com` as a Resource
+   pointing at the Newt site / `calibre-web-automated` service, port 8083.
+3. Still in Pangolin, add two rules on `books-sync.labmatt.com`, scoped to
+   path `/kobo/` (mirrors the existing `/metrics` block-path rule,
+   inverted):
+   - "Bypass Auth" - a Kobo can't complete an SSO redirect or hold a
+     session cookie.
+   - Rate limit - this path is the one thing not covered by SSO.
+4. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
+   the per-user sync token/URL.
+5. On the Kobo device, point it at
+   `https://books-sync.labmatt.com/kobo/<token>/`.

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -6,26 +6,12 @@ Ebook library + Kobo device sync. See GitHub issue #17 for the full design
 
 The manifests here are Flux-managed (`services/downloads-standard/
 kustomization.yaml`) - merging to `main` deploys them, no manual
-`kubectl apply` needed. Two steps stay manual:
+`kubectl apply` needed. DNS (`infrastructure/cloudflare/opentofu`) and the
+Pangolin Resource (`infrastructure/tunnel/blueprints/books-sync.yaml`) for
+`books-sync.labmatt.com` are handled in their own directories - see those
+for the apply steps. Once those are applied:
 
-1. `tofu apply` in `infrastructure/cloudflare/opentofu` to create the
-   `books-sync` DNS record (already added to `tunnel_hostnames`):
-```bash
-cd infrastructure/cloudflare/opentofu && tofu apply
-```
-2. Apply `infrastructure/tunnel/blueprints/books-sync.yaml` via the
-   Pangolin dashboard's Settings > Blueprints page - see that
-   directory's README for the full workflow. It points
-   `books-sync.labmatt.com` at the `ingress-nginx` LoadBalancer (port
-   80), same as `mattflix.labmatt.com` - **not** directly at the
-   `calibre-web-automated` Service, which would bypass
-   `ingress-books-sync.yaml`'s `/kobo/`-only path restriction and expose
-   the full admin UI on this host. SSO is deliberately off for this
-   resource (a Kobo can't complete an SSO redirect); optionally add a
-   rate-limit rule on `/kobo/` by hand in the dashboard afterward - not
-   expressible in the Blueprint schema, see the blueprint file's own
-   comment.
-3. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
+1. In CWA's admin UI (`books.labmatt.com`), enable Kobo Sync and generate
    the per-user sync token/URL.
-4. On the Kobo device, point it at
+2. On the Kobo device, point it at
    `https://books-sync.labmatt.com/kobo/<token>/`.

--- a/services/downloads-standard/calibre-web-automated/README.md
+++ b/services/downloads-standard/calibre-web-automated/README.md
@@ -4,10 +4,8 @@ Ebook library + Kobo device sync. See GitHub issue #17 for the full design
 (two-hostname split: `books.labmatt.com` tailnet-only admin UI,
 `books-sync.labmatt.com` path-restricted Kobo sync via Pangolin).
 
-The manifests here are Flux-managed (`services/downloads-standard/
-kustomization.yaml`) - merging to `main` deploys them, no manual
-`kubectl apply` needed. DNS (`infrastructure/cloudflare/opentofu`) and the
-Pangolin Resource (`infrastructure/tunnel/blueprints/books-sync.yaml`) for
+DNS (`infrastructure/cloudflare/opentofu`) and the Pangolin Resource
+(`infrastructure/tunnel/blueprints/books-sync.yaml`) for
 `books-sync.labmatt.com` are handled in their own directories - see those
 for the apply steps. Once those are applied:
 

--- a/services/downloads-standard/calibre-web-automated/deployment.yaml
+++ b/services/downloads-standard/calibre-web-automated/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: calibre-web-automated
+  namespace: downloads-standard
+spec:
+  replicas: 1
+  # RollingUpdate would briefly run two pods against cwa-config/cwa-library
+  # at once. nfs-provisioner doesn't enforce ReadWriteOnce exclusivity, so
+  # concurrent writers from two nodes can corrupt CWA's SQLite metadata db.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: calibre-web-automated
+  template:
+    metadata:
+      labels:
+        app: calibre-web-automated
+    spec:
+      containers:
+      - name: calibre-web-automated
+        image: crocodilestick/calibre-web-automated:latest
+        ports:
+        - containerPort: 8083
+          name: http
+        env:
+        - name: PUID
+          value: "1000"
+        - name: PGID
+          value: "1000"
+        - name: TZ
+          value: "America/New_York"
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        - name: library
+          mountPath: /calibre-library
+        - name: ingest
+          mountPath: /cwa-book-ingest
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "250m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+      volumes:
+      - name: config
+        persistentVolumeClaim:
+          claimName: cwa-config
+      - name: library
+        persistentVolumeClaim:
+          claimName: cwa-library
+      - name: ingest
+        persistentVolumeClaim:
+          claimName: cwa-ingest

--- a/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
+++ b/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
@@ -1,0 +1,39 @@
+# Kobo device sync only, routed through Pangolin (books-sync added to
+# tunnel_hostnames in infrastructure/cloudflare/opentofu). Only the
+# /kobo/ prefix is declared here, so anything else on this host 404s at
+# the ingress level - a Pangolin config drift can't accidentally expose
+# the admin UI (see ingress.yaml) through this host. Unlike
+# jellyfin/ingress-block-metrics.yaml, no separate block rule is needed:
+# there's no other Ingress on books-sync.labmatt.com to shadow, so
+# nginx's default 404 already covers every other path.
+#
+# CWA's Kobo Sync token is embedded directly in the URL
+# (/kobo/<token>/...) and checked per-request by CWA itself - that token
+# is the entire auth for this path by design. See issue #17 for the full
+# reasoning and the required Pangolin dashboard steps (bypass-auth +
+# rate-limit rule scoped to /kobo/) that aren't managed as code here.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: calibre-web-automated-books-sync
+  namespace: downloads-standard
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - books-sync.labmatt.com
+      secretName: books-sync-tls
+  rules:
+  - host: books-sync.labmatt.com
+    http:
+      paths:
+      - path: /kobo/
+        pathType: Prefix
+        backend:
+          service:
+            name: calibre-web-automated
+            port:
+              number: 8083

--- a/services/downloads-standard/calibre-web-automated/ingress.yaml
+++ b/services/downloads-standard/calibre-web-automated/ingress.yaml
@@ -1,0 +1,30 @@
+# Full web UI/admin, tailnet/LAN-only: resolves via the *.labmatt.com
+# wildcard -> in-cluster ingress-nginx LoadBalancer's private IP, never
+# touches Pangolin. Same pattern as sonarr.labmatt.com. See
+# ingress-books-sync.yaml for the separate, path-restricted public host
+# used for Kobo device sync.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: calibre-web-automated
+  namespace: downloads-standard
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - books.labmatt.com
+      secretName: books-tls
+  rules:
+  - host: books.labmatt.com
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: calibre-web-automated
+            port:
+              number: 8083

--- a/services/downloads-standard/calibre-web-automated/pvc-config.yaml
+++ b/services/downloads-standard/calibre-web-automated/pvc-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cwa-config
+  namespace: downloads-standard
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-provisioner
+  resources:
+    requests:
+      storage: 5Gi

--- a/services/downloads-standard/calibre-web-automated/pvc-ingest.yaml
+++ b/services/downloads-standard/calibre-web-automated/pvc-ingest.yaml
@@ -1,0 +1,17 @@
+# CWA's watched ingest folder: anything dropped here is auto-converted and
+# imported into cwa-library, then removed from here. Kept small and
+# separate from the library PVC since it's meant to be transient. The
+# future book-acquisition ticket (issue #18) will point its output at
+# this same PVC/mount.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cwa-ingest
+  namespace: downloads-standard
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-provisioner
+  resources:
+    requests:
+      storage: 5Gi

--- a/services/downloads-standard/calibre-web-automated/pvc-library.yaml
+++ b/services/downloads-standard/calibre-web-automated/pvc-library.yaml
@@ -1,0 +1,15 @@
+# The actual Calibre library (books + metadata.db). Deliberately its own
+# PVC, separate from pv-media-standard-downloads - this is long-term
+# storage CWA owns and writes to directly, not a downloads staging area.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cwa-library
+  namespace: downloads-standard
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-provisioner
+  resources:
+    requests:
+      storage: 50Gi

--- a/services/downloads-standard/calibre-web-automated/service.yaml
+++ b/services/downloads-standard/calibre-web-automated/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: calibre-web-automated
+  namespace: downloads-standard
+spec:
+  type: ClusterIP
+  selector:
+    app: calibre-web-automated
+  ports:
+    - port: 8083
+      targetPort: 8083
+      protocol: TCP
+      name: http

--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -54,3 +54,10 @@ resources:
   - qbittorrent-vpn/ingress.yaml
   - qbittorrent-vpn/pvc-config.yaml
   - qbittorrent-vpn/service.yaml
+  - calibre-web-automated/deployment.yaml
+  - calibre-web-automated/ingress.yaml
+  - calibre-web-automated/ingress-books-sync.yaml
+  - calibre-web-automated/pvc-config.yaml
+  - calibre-web-automated/pvc-ingest.yaml
+  - calibre-web-automated/pvc-library.yaml
+  - calibre-web-automated/service.yaml


### PR DESCRIPTION
Closes #17.

Two-hostname split: `books.labmatt.com` is the tailnet/LAN-only admin UI (existing `*.labmatt.com` wildcard -> in-cluster ingress-nginx), same pattern as `sonarr.labmatt.com`. `books-sync.labmatt.com` is Kobo device sync only, routed through Pangolin, restricted at the ingress level to the `/kobo/` path prefix so nothing else on that host is reachable even if the Pangolin config drifts.

Adds `books-sync` to `tunnel_hostnames` for the Pangolin DNS record. CWA gets its own config/library/ingest PVCs, separate from `pv-media-standard-downloads`, reusing the existing `qbittorrent-vpn` + `prowlarr` in `downloads-standard` (no new AirVPN port).

Rebased onto main to pick up the Flux cutover (#15) and Pangolin Blueprints (#7/#99) that landed while this PR was held:
- CWA's manifests are wired into `services/downloads-standard/kustomization.yaml`, so Flux deploys them on merge - no manual `kubectl apply`.
- `infrastructure/tunnel/blueprints/books-sync.yaml` tracks the Pangolin Resource for `books-sync.labmatt.com` as code (SSO off, target points at `ingress-nginx` so the `/kobo/`-only path restriction still applies). Rate limiting on `/kobo/` isn't expressible in the Blueprint schema, so that one rule stays a manual dashboard step.

Acquisition automation (Chaptarr or similar) is out of scope here, tracked separately as issue #18.

## Verified
- `kubectl kustomize` + server-side `--dry-run=server` clean for the whole `downloads-standard` render
- `tofu validate` passes on the opentofu config

## Manual steps after merge (see service README)
- `tofu apply` in `infrastructure/cloudflare/opentofu` to create the `books-sync` DNS record
- Apply `infrastructure/tunnel/blueprints/books-sync.yaml` via the Pangolin dashboard's Settings > Blueprints page; optionally add a rate-limit rule on `/kobo/` by hand afterward
- Enable Kobo Sync in CWA's UI, set token on device
