### PR TITLE
tunnel: source SSH public key from a variable instead of a local file path

### DIFF
--- a/infrastructure/tunnel/opentofu/main.tf
+++ b/infrastructure/tunnel/opentofu/main.tf
@@ -1,6 +1,6 @@
 resource "hcloud_ssh_key" "homelab" {
   name       = "homelab-key"
-  public_key = file("~/.ssh/id_ed25519.pub")
+  public_key = var.ssh_public_key
 }
 
 resource "hcloud_server" "edge_proxy" {

--- a/infrastructure/tunnel/opentofu/variables.tf
+++ b/infrastructure/tunnel/opentofu/variables.tf
@@ -22,3 +22,8 @@ variable "hcloud_token" {
   sensitive   = true
 }
 
+variable "ssh_public_key" {
+  description = "Public SSH key installed on the edge proxy server (contents of e.g. ~/.ssh/id_ed25519.pub). Must include the trailing newline (set it as a heredoc in terraform.tfvars) - a value without one differs from what's already in state and forces the key, server, and floating IP to be replaced."
+  type        = string
+}
+


### PR DESCRIPTION
Split out of #22's review discussion.

## What

`hcloud_ssh_key.homelab` read `file("~/.ssh/id_ed25519.pub")` directly - fine for local applies (the key's always on the operator's machine) but not portable: it broke `tofu validate` in CI (#14/#22) since that path doesn't exist on a GitHub Actions runner, and would break the same way under any future apply automation that doesn't run from this exact laptop.

Sourced the key the same way `hcloud_token` already is in this file: a variable, filled in from the gitignored `terraform.tfvars`.

## Why not a dedicated key instead

Considered generating/uploading a separate SSH key just for this server, so it wouldn't reuse a personal identity key at all. Went with the simpler variable swap instead: `edge_proxy` is a single, already-running server with no automation touching it yet, so the isolation benefit is marginal today, and a dedicated key would need real migration care (Hetzner only applies `ssh_keys` at server creation, so swapping the underlying key needs either state surgery or a manual `authorized_keys` update on the live box). Worth revisiting if/when this server's access needs to be handed to something other than a person, but not as part of a portability fix.

## Safety check

Verified this is a no-op against real infrastructure - `tofu plan` showed **no changes** once the tfvars value matched. (First attempt showed the SSH key, server, and floating IP all being destroyed/recreated - the tfvars value needs its trailing newline to byte-match what `file()` was previously reading; `variables.tf` now documents that.)
