### PR TITLE
Scope Renovate's flux manager to services/ and infrastructure/kubernetes/

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,13 @@
       "/^infrastructure/kubernetes/.+\\.ya?ml$/"
     ]
   },
+  "flux": {
+    "managerFilePatterns": [
+      "/^clusters/.+\\.ya?ml$/",
+      "/^services/.+\\.ya?ml$/",
+      "/^infrastructure/kubernetes/.+\\.ya?ml$/"
+    ]
+  },
   "packageRules": [
     {
       "description": "Group the *arr media stack together so a bump lands as one PR instead of one per app",


### PR DESCRIPTION
## Why

After #28 merged (kube-prometheus-stack as a Flux HelmRelease), a manual
Renovate run against `main` showed its `flux` manager only detected
`clusters/eye-of-michael/flux-system/gotk-components.yaml` (the Flux
version itself) - not the new
`infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml`,
so chart version bumps wouldn't have opened PRs.

## What

Give the `flux` manager the same explicit path scope already set for the
`kubernetes` manager (`services/`, `infrastructure/kubernetes/`), plus
`clusters/` to keep covering what it already found there.

## Verification plan

Once merged, I'll trigger another manual Renovate run and check the
Dependency Dashboard lists `kube-prometheus-stack 84.2.1` under `flux`.