### PR TITLE
Cut database over to Flux

### DIFF
--- a/clusters/eye-of-michael/flux-system/database.yaml
+++ b/clusters/eye-of-michael/flux-system/database.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: database
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/database
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -4,3 +4,4 @@ resources:
   - gotk-components.yaml
   - gotk-sync.yaml
   - observability.yaml
+  - database.yaml

--- a/infrastructure/kubernetes/database/kustomization.yaml
+++ b/infrastructure/kubernetes/database/kustomization.yaml
@@ -1,0 +1,8 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/database.yaml for
+# the Kustomization CR that reconciles this path. Second cutover under #15,
+# after observability.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - postgres-cluster.yaml


### PR DESCRIPTION
## What

Second per-category cutover under #15 (after observability, #28). The
`database` directory is just a namespace + a CNPG `Cluster` CR - no Helm
involved, so this is a simpler version of the same pattern: a
`kustomization.yaml` listing the managed resources, and a Flux
`Kustomization` CR in `clusters/eye-of-michael/flux-system/` wired into
that directory's self-reconcile.

## Verified

- `kubectl kustomize infrastructure/kubernetes/database` builds cleanly.
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/database`
  against the live cluster: both resources come back `unchanged`.
- `kubectl apply --dry-run=server -k clusters/eye-of-michael/flux-system`
  succeeds with the new `database` Kustomization CR included.

Same as before: no manual step needed after merge, `flux-system`'s
self-reconcile (≤1m) picks it up automatically.