### PR TITLE
Cut storage over to Flux

### DIFF
--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - gotk-sync.yaml
   - observability.yaml
   - database.yaml
+  - storage.yaml

--- a/clusters/eye-of-michael/flux-system/storage.yaml
+++ b/clusters/eye-of-michael/flux-system/storage.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: storage
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/storage
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/infrastructure/kubernetes/storage/kustomization.yaml
+++ b/infrastructure/kubernetes/storage/kustomization.yaml
@@ -1,0 +1,7 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/storage.yaml for the
+# Kustomization CR that reconciles this path. Third cutover under #15, after
+# observability and database.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - nfs-provisioner.yaml


### PR DESCRIPTION
## What

Third per-category cutover under #15 (after observability #28, database
#32). `infrastructure/kubernetes/storage/nfs-provisioner.yaml` is a single
self-contained manifest (namespace, ServiceAccount, ClusterRole,
ClusterRoleBinding, Deployment, StorageClass) - no Helm involved. Same
pattern: `kustomization.yaml` in that directory, Flux `Kustomization` CR in
`clusters/eye-of-michael/flux-system/`.

Worth calling out explicitly since this one backs both prior cutovers
(`nfs-provisioner` StorageClass is what `observability` and `database`'s
PVCs use): the risk here is scoped to *new* PVC provisioning, not existing
data - the provisioner doesn't hold state for already-bound PVs, those are
independent NFS-backed volumes.

## Verified

- `kubectl kustomize infrastructure/kubernetes/storage` builds cleanly.
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/storage`
  against the live cluster: all six resources come back `unchanged`.
- `kubectl apply --dry-run=server -k clusters/eye-of-michael/flux-system`
  succeeds with the new `storage` Kustomization CR included.