### PR TITLE
Revert kube-prometheus-stack to 84.5.0

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -12,9 +12,13 @@ spec:
   chart:
     spec:
       chart: kube-prometheus-stack
-      # Pinned to the version already running so this cutover is a no-op
-      # upgrade. Renovate bumps this going forward.
-      version: "88.5.4"
+      # Reverted from 88.5.4 (2026-08-25): that upgrade's HelmRelease timed
+      # out and failed to remediate cleanly while the cluster hit unrelated
+      # node instability mid-rollout, and was suspended + manually rolled
+      # back to stop further retries. Back to the last known-good version
+      # until the broader rollout-safety issue this surfaced (see follow-up
+      # ticket) is understood and fixed.
+      version: "84.5.0"
       sourceRef:
         kind: HelmRepository
         name: prometheus-community


### PR DESCRIPTION
## What

Reverts the `88.5.4` bump (#31) back to `84.5.0`.

## Why

The `88.5.4` upgrade's `HelmRelease` timed out (default 5m timeout, chart
major bump needed fresh image pulls across many pods at once) and
triggered automatic rollback remediation - which itself also timed out on
a retry, while the cluster separately hit real node instability
(`k8s-razlo-w1`/`w2`, `k8s-nicholas-w2`, and briefly `k8s-razlo-cp` all went
`NotReady` during this window, self-recovering each time). Whether the node
instability caused the timeout or the compounding upgrade/rollback churn
caused the node instability isn't fully understood yet - a broader ticket
covering that is coming once it's diagnosed properly, not guessed at here.

To stop further automatic retries against a target we haven't cleared as
safe, the `HelmRelease` was suspended (`flux suspend helmrelease
kube-prometheus-stack -n observability`) and the live release manually
confirmed back on `84.5.0` (`helm status`: `deployed`, revision 28, matches
what was running before #31). This PR just brings git back in sync with
that already-live, already-verified-healthy state.

## After merge

Needs `flux resume helmrelease kube-prometheus-stack -n observability` to
resume normal reconciliation - I'll do that once this merges.