### PR TITLE
Stop generating talosconfig as a repo-tree file

### DIFF
--- a/docs/bootstrap/terraform.md
+++ b/docs/bootstrap/terraform.md
@@ -1,17 +1,22 @@
-# Terraform Bootstrapping
+# OpenTofu Bootstrapping
 
-Configuring Terraform to automate Proxmox VM provisioning for Kubernetes cluster.
+Configuring OpenTofu to automate Proxmox VM provisioning for Kubernetes cluster.
+
+> This project uses [OpenTofu](https://opentofu.org/) (the `tofu` CLI), not
+> Terraform — see [ADR 001](/docs/adr/001-kubernetes-distribution-and-virtualization-layer.md).
+> The `terraform` CLI is drop-in compatible if you already have it installed,
+> but commands below use `tofu`.
 
 ## Prerequisites
 - Proxmox cluster operational
 - SDN configured with k8sVNet (10.0.10.0/24)
 - Tailscale subnet configured (if using Tailnet)
-- Terraform installed on local machine ([install guide](https://developer.hashicorp.com/terraform/install))
+- OpenTofu installed on local machine ([install guide](https://opentofu.org/docs/intro/install/))
 - Talos templates created on each Proxmox node ([see Talos guide](./talos.md))
 
 ## Overview
 
-What Terraform setup provides:
+What the OpenTofu setup provides:
 - Infrastructure as code for VM provisioning
 - Automated Talos configuration and cluster bootstrapping
 - Reproducible environment setup
@@ -19,7 +24,7 @@ What Terraform setup provides:
 
 ## Architecture
 ```
-Terraform (Local Machine)
+OpenTofu (Local Machine)
     ↓ API calls over HTTPS
     ├─→ Proxmox API (Token Auth)
     │       ↓ Creates VMs
@@ -95,21 +100,21 @@ proxmox_nodes = [
 ```
 `terraform.tfvars` is gitignored as it contains secrets
 
-2. Init terraform
+2. Init OpenTofu
 ```bash
-cd infrastructure/terraform/proxmox
-terraform init
+cd infrastructure/proxmox/opentofu
+tofu init
 ```
 3. Validate configuration
 ```bash
-terraform validate
-terraform plan
+tofu validate
+tofu plan
 ```
 
-### Step 3: Apply Terraform Configuration
+### Step 3: Apply OpenTofu Configuration
 1. Apply configuration to create VMs
 ```bash
-terraform apply
+tofu apply
 ```
 
 2. Verify VMs created in Proxmox UI or via CLI
@@ -123,18 +128,26 @@ pvesh get /cluster/resources --type vm
 ping -c 3 10.0.10.10
 ```
 
+The commands below assume `~/.talos/config` (talosctl's default config)
+already has a working context for this cluster. If `talosctl` fails with
+`x509: certificate signed by unknown authority`, that context is stale or
+missing — pull a fresh one straight from OpenTofu state:
+```bash
+tofu output -raw talosconfig > ~/.talos/config
+```
+
 2. Bootstrap Kubernetes cluster using Talosctl
 ```bash
-talosctl --talosconfig ./talosconfig bootstrap --nodes 10.0.10.10
+talosctl bootstrap --nodes 10.0.10.10
 ```
 
 3. Wait 1-2 minutes, then verify cluster health
 ```bash
-talosctl --talosconfig ./talosconfig --nodes 10.0.10.10 health
-talosctl --talosconfig ./talosconfig --nodes 10.0.10.10 etcd members
+talosctl --nodes 10.0.10.10 health
+talosctl --nodes 10.0.10.10 etcd members
 ```
 
 4. Generate kubeconfig for kubectl access
 ```bash
-talosctl kubeconfig --nodes 10.0.10.10 --talosconfig ./talosconfig
+talosctl kubeconfig --nodes 10.0.10.10
 ```

--- a/infrastructure/proxmox/opentofu/.gitignore
+++ b/infrastructure/proxmox/opentofu/.gitignore
@@ -1,4 +1,3 @@
-talosconfig
 kubeconfig
 terraform.tfvars
 *.tfstate*

--- a/infrastructure/proxmox/opentofu/README.md
+++ b/infrastructure/proxmox/opentofu/README.md
@@ -12,13 +12,23 @@ tofu apply
 
 ## Bootstrap Cluster
 
+The talosconfig is rendered on demand from OpenTofu state via `tofu output` —
+it is not written to disk automatically. Materialize it straight to
+talosctl's default lookup path first:
+```bash
+tofu output -raw talosconfig > ~/.talos/config
+```
+Re-run that whenever the cluster's certs are regenerated (e.g. an apply that
+recreates `talos_machine_secrets`), or `~/.talos/config` goes stale and
+`talosctl` fails with `x509: certificate signed by unknown authority`.
+
 Initialize Kubernetes and generate kubeconfig:
 ```bash
 # Bootstrap etcd and control plane
-talosctl bootstrap --nodes 10.0.10.30 --talosconfig ./talosconfig
+talosctl bootstrap --nodes 10.0.10.30
 
 # Generate kubeconfig for kubectl access
-talosctl kubeconfig --nodes 10.0.10.30 --talosconfig ./talosconfig --force
+talosctl kubeconfig --nodes 10.0.10.30 --force
 
 # Verify cluster
 kubectl get nodes

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -46,12 +46,12 @@ locals {
 data "talos_machine_configuration" "controlplane" {
   for_each = local.control_plane_nodes
 
-  cluster_name         = var.cluster_name
-  cluster_endpoint     = local.cluster_endpoint
-  machine_type         = "controlplane"
-  machine_secrets      = talos_machine_secrets.cluster.machine_secrets
-  talos_version        = local.talos_version
-  kubernetes_version   = local.kubernetes_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  machine_type       = "controlplane"
+  machine_secrets    = talos_machine_secrets.cluster.machine_secrets
+  talos_version      = local.talos_version
+  kubernetes_version = local.kubernetes_version
 
   config_patches = [
     yamlencode({
@@ -118,19 +118,19 @@ data "talos_client_configuration" "this" {
 resource "local_file" "user_data" {
   for_each = local.control_plane_nodes
 
-  content  = data.talos_machine_configuration.controlplane[each.key].machine_configuration
-  filename = "${path.module}/iso-content/control-plane/${each.key}/user-data"
+  content         = data.talos_machine_configuration.controlplane[each.key].machine_configuration
+  filename        = "${path.module}/iso-content/control-plane/${each.key}/user-data"
   file_permission = "0600"
 }
 
 resource "local_file" "meta_data" {
   for_each = local.control_plane_nodes
 
-  content  = yamlencode({
+  content = yamlencode({
     instance_id    = each.value.hostname
     local_hostname = each.value.hostname
   })
-  filename = "${path.module}/iso-content/control-plane/${each.key}/meta-data"
+  filename        = "${path.module}/iso-content/control-plane/${each.key}/meta-data"
   file_permission = "0600"
 }
 
@@ -167,12 +167,12 @@ resource "null_resource" "upload_control_plane_iso" {
 data "talos_machine_configuration" "worker" {
   for_each = local.worker_nodes
 
-  cluster_name         = var.cluster_name
-  cluster_endpoint     = local.cluster_endpoint
-  machine_type         = "worker"
-  machine_secrets      = talos_machine_secrets.cluster.machine_secrets
-  talos_version        = local.talos_version
-  kubernetes_version   = local.kubernetes_version
+  cluster_name       = var.cluster_name
+  cluster_endpoint   = local.cluster_endpoint
+  machine_type       = "worker"
+  machine_secrets    = talos_machine_secrets.cluster.machine_secrets
+  talos_version      = local.talos_version
+  kubernetes_version = local.kubernetes_version
 
   config_patches = [
     yamlencode({
@@ -218,11 +218,11 @@ resource "local_file" "worker_user_data" {
 resource "local_file" "worker_meta_data" {
   for_each = local.worker_nodes
 
-  content  = yamlencode({
+  content = yamlencode({
     instance_id    = each.value.hostname
     local_hostname = each.value.hostname
   })
-  filename = "${path.module}/iso-content/worker/${each.key}/meta-data"
+  filename        = "${path.module}/iso-content/worker/${each.key}/meta-data"
   file_permission = "0600"
 }
 

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -105,18 +105,13 @@ data "talos_machine_configuration" "controlplane" {
   ]
 }
 
-# Generate talosconfig for cluster access
+# Talos client configuration for cluster access — rendered on demand via the
+# `talosconfig` output (see outputs.tf), not written to disk automatically.
 data "talos_client_configuration" "this" {
   cluster_name         = var.cluster_name
   client_configuration = talos_machine_secrets.cluster.client_configuration
   endpoints            = [local.bootstrap_node.ip_address]
   nodes                = [for node in local.control_plane_nodes : node.ip_address]
-}
-
-resource "local_file" "talosconfig" {
-  content  = data.talos_client_configuration.this.talos_config
-  filename = "${path.module}/talosconfig"
-  file_permission = "0600"
 }
 
 # Create ISO content for each control plane

--- a/infrastructure/proxmox/opentofu/outputs.tf
+++ b/infrastructure/proxmox/opentofu/outputs.tf
@@ -1,7 +1,9 @@
-# Talos config file location
-output "talosconfig_path" {
-  description = "Path to the Talos config file"
-  value       = abspath("${path.module}/talosconfig")
+# Talos client config, rendered on demand from state (not written to disk automatically).
+# Materialize it with: tofu output -raw talosconfig > ~/.talos/config
+output "talosconfig" {
+  description = "Talos client configuration (talosconfig) for the cluster"
+  value       = data.talos_client_configuration.this.talos_config
+  sensitive   = true
 }
 
 # Cluster endpoint

--- a/infrastructure/proxmox/opentofu/outputs.tf
+++ b/infrastructure/proxmox/opentofu/outputs.tf
@@ -28,9 +28,9 @@ output "control_plane_nodes" {
   description = "All control plane nodes"
   value = {
     for key, node in local.control_plane_nodes : key => {
-      hostname   = node.hostname
-      ip_address = node.ip_address
-      vm_id      = node.vm_id
+      hostname     = node.hostname
+      ip_address   = node.ip_address
+      vm_id        = node.vm_id
       proxmox_node = node.proxmox_node
     }
   }


### PR DESCRIPTION
## Problem

`talosctl` was failing with `x509: certificate signed by unknown authority` on plain commands (no flags). The root cause: `~/.talos/config` (talosctl's default config lookup path) held a client cert/CA from a previous cluster generation, while OpenTofu's `local_file.talosconfig` resource kept regenerating a *separate*, up-to-date copy at `infrastructure/proxmox/opentofu/talosconfig` on every `tofu apply`. Two copies of the same secret with no mechanism keeping them in sync — the repo-tree copy stayed current, the default-location copy silently went stale.

Along the way, several other stray empty `talosconfig` stub files were found scattered around the filesystem (`infrastructure/kubernetes/talosconfig`, a duplicated `services/infrastructure/proxmox/opentofu/talosconfig` path, `~/talosconfig`) — leftovers from running `talosctl --talosconfig ./talosconfig ...` commands from the wrong working directory, since the docs told you to use a cwd-relative path. Those have been deleted.

## Fix

Removed the `local_file.talosconfig` resource entirely. `~/.talos/config` is now the only file that matters — talosctl finds it automatically with zero flags, from any directory. If it's ever missing or stale, there's a one-line fix documented (not a required routine step): a sensitive `talosconfig` output lets you regenerate it on demand straight from OpenTofu state:

```bash
tofu output -raw talosconfig > ~/.talos/config
```

Updated `infrastructure/proxmox/opentofu/README.md` and `docs/bootstrap/terraform.md` to drop every `--talosconfig ./talosconfig` / cwd-relative reference, and fixed `docs/bootstrap/terraform.md`'s stale references to a nonexistent `infrastructure/terraform/proxmox` path and the `terraform` CLI (this module uses OpenTofu / `tofu`).