### PR TITLE
Run tofu fmt across all OpenTofu modules

### DIFF
--- a/infrastructure/home-assistant/opentofu/main.tf
+++ b/infrastructure/home-assistant/opentofu/main.tf
@@ -21,9 +21,9 @@ resource "proxmox_virtual_environment_vm" "home_assistant" {
   }
 
   efi_disk {
-    datastore_id = "local"
+    datastore_id      = "local"
     pre_enrolled_keys = false
-    type = "4m"
+    type              = "4m"
   }
 
   disk {

--- a/infrastructure/home-assistant/opentofu/providers.tf
+++ b/infrastructure/home-assistant/opentofu/providers.tf
@@ -15,12 +15,12 @@ provider "proxmox" {
   insecure  = true
 
   ssh {
-  agent    = true
-  username = "root"
-  node {
-    name    = var.proxmox_node.name
-    address = var.proxmox_node.host_ip
-    port    = 22
+    agent    = true
+    username = "root"
+    node {
+      name    = var.proxmox_node.name
+      address = var.proxmox_node.host_ip
+      port    = 22
+    }
   }
-}
 }

--- a/infrastructure/proxmox/opentofu/locals.tf
+++ b/infrastructure/proxmox/opentofu/locals.tf
@@ -1,8 +1,8 @@
 locals {
   # Versions
   kubernetes_version = "v1.34.1"
-  talos_version = "v1.13.8"
-  kube_vip_version = "v1.0.1"
+  talos_version      = "v1.13.8"
+  kube_vip_version   = "v1.0.1"
 
   # Pinned to whatever version the cluster was originally bootstrapped with - this is NOT
   # the fleet's current/target OS version (that's talos_version above) and must never track
@@ -20,7 +20,7 @@ locals {
   # Order matters - the Image Factory hashes the literal request, so this order matches
   # what's already live on the fleet (see docs/bootstrap/talos.md's schematic ID) rather
   # than producing a different-but-equivalent schematic for the same two extensions.
-  worker_extensions         = ["siderolabs/i915", "siderolabs/qemu-guest-agent"]
+  worker_extensions = ["siderolabs/i915", "siderolabs/qemu-guest-agent"]
 
   # GPU passthrough - the livio host's Intel HD 630 iGPU is passed through
   # exclusively to this one worker (a PCI device can only be owned by one VM
@@ -58,16 +58,16 @@ locals {
   # Workers - Many per Proxmox host
   worker_nodes = merge([
     for host_idx, host in var.proxmox_hosts :
-      { for worker_idx, worker in host.workers:
-        "${host.name}-w${worker_idx + 1}" => {
-          proxmox_node   = host.name
-          vm_id          = local.worker_vm_id_base + (host_idx * 10) + worker_idx + 1
-          ip_address     = worker.ip_address
-          mac_address    = worker.mac_address
-          hostname       = "k8s-${host.name}-w${worker_idx + 1}"
-          cores          = worker.cores
-          memory_mb      = worker.memory_mb
-          template_vm_id = host.template_vm_id
+    { for worker_idx, worker in host.workers :
+      "${host.name}-w${worker_idx + 1}" => {
+        proxmox_node   = host.name
+        vm_id          = local.worker_vm_id_base + (host_idx * 10) + worker_idx + 1
+        ip_address     = worker.ip_address
+        mac_address    = worker.mac_address
+        hostname       = "k8s-${host.name}-w${worker_idx + 1}"
+        cores          = worker.cores
+        memory_mb      = worker.memory_mb
+        template_vm_id = host.template_vm_id
       }
     }
   ]...)

--- a/infrastructure/proxmox/opentofu/providers.tf
+++ b/infrastructure/proxmox/opentofu/providers.tf
@@ -21,9 +21,9 @@ terraform {
 }
 
 provider "proxmox" {
-  endpoint = var.proxmox_host
+  endpoint  = var.proxmox_host
   api_token = "${var.proxmox_token_id}=${var.proxmox_token_secret}"
-  insecure = true
+  insecure  = true
 
   ssh {
     agent = true

--- a/infrastructure/proxmox/opentofu/variables.tf
+++ b/infrastructure/proxmox/opentofu/variables.tf
@@ -25,27 +25,27 @@ variable "proxmox_hosts" {
     host_reserved_mb = number
     template_vm_id   = number
 
-    control_plane    = object({
-      ip_address       = string
-      mac_address      = string
-      cores            = number
-      memory_mb        = number
+    control_plane = object({
+      ip_address  = string
+      mac_address = string
+      cores       = number
+      memory_mb   = number
     })
 
-    workers          = list(object({
-      ip_address       = string
-      mac_address      = string
-      cores            = number
-      memory_mb        = number
+    workers = list(object({
+      ip_address  = string
+      mac_address = string
+      cores       = number
+      memory_mb   = number
     }))
   }))
 
   validation {
     condition = alltrue([
       for host in var.proxmox_hosts :
-      (host.control_plane.memory_mb + sum([for w in host.workers : w.memory_mb]) + host.host_reserved_mb) <= host.memory_mb])
+    (host.control_plane.memory_mb + sum([for w in host.workers : w.memory_mb]) + host.host_reserved_mb) <= host.memory_mb])
 
-      error_message = "Total VM memory allocation + host_reserved_mb exceeds total host memory on one or more hosts."
+    error_message = "Total VM memory allocation + host_reserved_mb exceeds total host memory on one or more hosts."
   }
 
   default = [

--- a/infrastructure/proxmox/opentofu/vms.tf
+++ b/infrastructure/proxmox/opentofu/vms.tf
@@ -31,7 +31,7 @@ resource "proxmox_virtual_environment_vm" "control_plane" {
   }
 
   cdrom {
-    file_id   = "local:iso/${each.key}-cp.iso"
+    file_id = "local:iso/${each.key}-cp.iso"
   }
 
   depends_on = [null_resource.upload_control_plane_iso]
@@ -71,7 +71,7 @@ resource "proxmox_virtual_environment_vm" "worker" {
   }
 
   cdrom {
-    file_id   = "local:iso/${each.key}-w.iso"
+    file_id = "local:iso/${each.key}-w.iso"
   }
 
   depends_on = [null_resource.upload_worker_iso]

--- a/infrastructure/tunnel/opentofu/main.tf
+++ b/infrastructure/tunnel/opentofu/main.tf
@@ -8,9 +8,9 @@ resource "hcloud_server" "edge_proxy" {
   server_type = var.server_type
   location    = var.location
   image       = "ubuntu-24.04"
-  
+
   ssh_keys = [hcloud_ssh_key.homelab.id]
-  
+
   public_net {
     ipv4_enabled = true
     ipv6_enabled = true


### PR DESCRIPTION
Whitespace-only cleanup — every changed line is alignment/spacing (verified with `git diff -w`, which shows zero remaining diff). `tofu fmt -check -recursive` now passes clean in every module (`infrastructure/home-assistant/opentofu`, `infrastructure/proxmox/opentofu`, `infrastructure/tunnel/opentofu`; `infrastructure/cloudflare/opentofu` was already clean). Each module still passes `tofu validate`.

No functional changes.

Note: this overlaps two files (`infrastructure/proxmox/opentofu/cluster.tf`, `outputs.tf`) also touched by #38. Merge #38 first to avoid a trivial rebase here.