### PR TITLE
Enable Grafana folder provisioning, folder flux-cluster and jellyfin dashboards

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/flux-cluster.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/flux-cluster.yaml
@@ -6,6 +6,8 @@ metadata:
   creationTimestamp: null
   labels:
     grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Infrastructure"
 data:
   flux-cluster.json: |-
     {

--- a/infrastructure/kubernetes/observability/dashboards/jellyfin-process-health.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/jellyfin-process-health.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: observability
   labels:
     grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Services"
 data:
   jellyfin-process-health.json: |
     {

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -110,6 +110,9 @@ spec:
       sidecar:
         dashboards:
           folderAnnotation: grafana_folder
+          provider:
+            # foldersFromFilesStructure to create folders in Grafana
+            foldersFromFilesStructure: true
 
       additionalDataSources:
         - name: Loki


### PR DESCRIPTION
## Problem

Grafana dashboards weren't landing in their annotated folders. The `grafana_folder` annotation on a dashboard ConfigMap only tells the k8s-sidecar which subdirectory (under `/tmp/dashboards`) to write that dashboard's file into — Grafana's file provisioner needs a separate setting, `foldersFromFilesStructure: true`, to actually turn that directory structure into folders. Without it, the provisioner (`options.foldersFromFilesStructure: false` by chart default) ignores the structure and imports everything flat into the root folder regardless of the annotation.

## Fix

- `kube-prometheus-stack/helmrelease.yaml`: set `sidecar.dashboards.provider.foldersFromFilesStructure: true`.
- `dashboards/flux-cluster.yaml`: add `grafana_folder: "Infrastructure"`, joining kubernetes/truenas/proxmox-overview which already had it.
- `dashboards/jellyfin-process-health.yaml`: add `grafana_folder: "Services"` (new folder).

## Verified

Applied the `HelmRelease` and both ConfigMaps directly to the live cluster ahead of this commit. Confirmed via the `grafana-sc-dashboard` sidecar's own logs that both dashboards land in their intended folders after the provisioner setting flipped, not just that the annotation is syntactically present.