### PR TITLE
Fix ConfigMap data key collision between kubernetes-overview and truenas-overview

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/kubernetes-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/kubernetes-overview.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     grafana_folder: "Infrastructure"
 data:
-  kubernetes-events.json: |
+  kubernetes-overview.json: |
     {
       "annotations": {
         "list": [

--- a/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
     grafana_folder: "Infrastructure"
 data:
-  kubernetes-events.json: |
+  truenas-overview.json: |
     {
       "annotations": {
         "list": [


### PR DESCRIPTION
Both dashboards' ConfigMap data key was `kubernetes-events.json` (copy-paste leftover). The sidecar writes each ConfigMap's dashboard file to `/tmp/dashboards/<folder>/<key>`, so both wrote to the same path and one silently overwrote the other on disk — only one of the two dashboards was ever actually reachable in Grafana at a time, depending on sync order.

Renamed each key to match the convention every other dashboard here follows (`<name>.json`). Their dashboard `uid`s were already distinct (`admws2b` vs `ad4w48q`), so this is a ConfigMap key rename only, no dashboard content change.

Verified live: applied both ConfigMaps directly to the cluster, confirmed via `kubectl exec` into the Grafana pod that both files now coexist distinctly on disk.