### PR TITLE
Pin Loki datasource uid to match dashboards that reference it

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -117,6 +117,7 @@ spec:
       additionalDataSources:
         - name: Loki
           type: loki
+          uid: loki
           access: proxy
           url: http://loki-gateway.observability.svc.cluster.local
           isDefault: false


### PR DESCRIPTION
Dashboards (`live-logs`, in progress) hardcode `{"type": "loki", "uid": "loki"}` as their datasource reference, but the `Loki` entry in `additionalDataSources` had no explicit `uid` — Grafana auto-generated a random one on first creation, so any dashboard referencing `loki` got no data (datasource not found), even though the query itself was fine against Loki directly.

Prometheus and Alertmanager already pin explicit `uid`s the same way; this makes Loki consistent.

## Note for this already-running cluster

Because Grafana persists its datasource registry (PVC-backed), the *existing* `Loki` entry already has its old auto-generated uid baked in — provisioning can't rename an existing datasource's uid by name-match alone, it just conflicts (`Datasource provisioning error: data source not found`, confirmed in the pod's logs while testing this live). After merge, the stale entry needs a one-time manual delete so the provisioner recreates it clean with `uid: loki`:
```bash
curl -X DELETE -u admin:$GF_SECURITY_ADMIN_PASSWORD http://localhost:3000/api/datasources/uid/<stale-uid>
curl -X POST -u admin:$GF_SECURITY_ADMIN_PASSWORD http://localhost:3000/api/admin/provisioning/datasources/reload
```
(run from inside the Grafana pod, or via `kubectl exec`). Not needed on a fresh install.