### PR TITLE
Wire in Live Logs dashboard

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/live-logs.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/live-logs.yaml
@@ -1,0 +1,92 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  creationTimestamp: null
+  name: live-logs
+  namespace: observability
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Infrastructure"
+data:
+  live-logs.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "loki",
+            "uid": "loki"
+          },
+          "gridPos": {
+            "h": 30,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "dedupStrategy": "none",
+            "enableInfiniteScrolling": false,
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Ascending",
+            "wrapLogMessage": true
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "loki",
+                "uid": "loki"
+              },
+              "editorMode": "code",
+              "expr": "{namespace=~\".+\"} !~ `(?i)(healthz|readyz|livez|kube-probe|GET /metrics)`",
+              "queryType": "range",
+              "refId": "A"
+            }
+          ],
+          "title": "Live Cluster Logs (noise filtered)",
+          "type": "logs"
+        }
+      ],
+      "preload": false,
+      "refresh": "5s",
+      "schemaVersion": 42,
+      "tags": ["logs", "live"],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-5m",
+        "to": "now"
+      },
+      "timepicker": {},
+      "timezone": "browser",
+      "title": "Live Logs",
+      "uid": "live-logs-feed",
+      "version": 1
+    }

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -13,6 +13,7 @@ resources:
   - dashboards/flux-cluster.yaml
   - dashboards/jellyfin-process-health.yaml
   - dashboards/kubernetes-overview.yaml
+  - dashboards/live-logs.yaml
   - dashboards/proxmox-overview.yaml
   - dashboards/truenas-overview.yaml
   - flux-monitoring/podmonitor.yaml


### PR DESCRIPTION
Cluster-wide Loki log stream (all namespaces, 5s refresh, health-check/probe noise filtered out) in the Infrastructure folder, alongside kubernetes/truenas/proxmox-overview and flux-cluster.

Depends on #42 (Loki datasource uid fix, already merged) for the panel to actually render data.

Verified live: applied the ConfigMap directly, confirmed it renders data and lands in the Infrastructure folder per the sidecar's own log.