### PR TITLE
Deploy Wekan for volunteer project-management trial

### DIFF
--- a/infrastructure/cloudflare/opentofu/variables.tf
+++ b/infrastructure/cloudflare/opentofu/variables.tf
@@ -43,6 +43,7 @@ variable "tunnel_hostnames" {
     "mattflix",
     "pangolin",
     "pangolin-test",
+    "wekan",
   ]
 }
 

--- a/infrastructure/tunnel/blueprints/wekan.yaml
+++ b/infrastructure/tunnel/blueprints/wekan.yaml
@@ -8,8 +8,3 @@ public-resources:
         method: http
         hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
         port: 80
-    rules:
-      - action: allow
-        match: country
-        value: US
-        priority: 1

--- a/infrastructure/tunnel/blueprints/wekan.yaml
+++ b/infrastructure/tunnel/blueprints/wekan.yaml
@@ -8,16 +8,8 @@ public-resources:
         method: http
         hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
         port: 80
-    auth:
-      sso-enabled: true
-      sso-roles:
-        - Member
     rules:
-      - action: deny
-        match: path
-        value: /metrics
-        priority: 1
       - action: allow
         match: country
         value: US
-        priority: 2
+        priority: 1

--- a/infrastructure/tunnel/blueprints/wekan.yaml
+++ b/infrastructure/tunnel/blueprints/wekan.yaml
@@ -1,0 +1,23 @@
+public-resources:
+  wekan:
+    name: "Wekan"
+    mode: http
+    full-domain: wekan.labmatt.com
+    targets:
+      - site: faithful-brachyurophis-fasciolatus
+        method: http
+        hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
+        port: 80
+    auth:
+      sso-enabled: true
+      sso-roles:
+        - Member
+    rules:
+      - action: deny
+        match: path
+        value: /metrics
+        priority: 1
+      - action: allow
+        match: country
+        value: US
+        priority: 2

--- a/services/code-for-boston/README.md
+++ b/services/code-for-boston/README.md
@@ -8,8 +8,7 @@ Kustomization CR that reconciles this path.
 ## Leantime
 
 Goals-focused project management, for a volunteer-feedback trial
-alongside Wekan (`wekan-trial` branch/PR) in the shared `code-for-boston`
-namespace.
+alongside Wekan (below) in the shared `code-for-boston` namespace.
 
 ### Dependencies
 
@@ -21,7 +20,22 @@ namespace.
 - Pangolin tunnel — `leantime.labmatt.com` is added to `tunnel_hostnames`
   in `infrastructure/cloudflare/opentofu`.
 
-### Manual steps (not yet automated)
+First run creates an admin account at first login on
+`leantime.labmatt.com`.
+
+## Wekan
+
+Trello-style kanban board, deployed for a volunteer-feedback trial
+alongside Leantime.
+
+- Needs MongoDB, not the shared Postgres cluster, so it gets its own
+  single-instance Mongo (`mongodb/`) reachable only in-cluster.
+- Exposed at `wekan.labmatt.com` via the Pangolin tunnel
+  (`tunnel_hostnames` in `infrastructure/cloudflare/opentofu`).
+
+First user to register becomes admin on `wekan.labmatt.com`.
+
+## Manual steps (not yet automated)
 
 These aren't covered by Flux and need doing once, after merge:
 
@@ -35,10 +49,7 @@ kubectl create secret generic leantime-postgres-credentials \
   --from-literal=password=$(openssl rand -hex 32)
 ```
 
-Also run `tofu apply` in `infrastructure/cloudflare/opentofu` for the DNS
-record (tracked for automation in #57), and create the matching resource
-+ access rule in the Pangolin dashboard per
+Also run `tofu apply` in `infrastructure/cloudflare/opentofu` for the two
+new DNS records (tracked for automation in #57), and create the matching
+resource + access rule for each hostname in the Pangolin dashboard per
 `infrastructure/tunnel/blueprints/README.md` (tracked in #7).
-
-First run creates an admin account at first login on
-`leantime.labmatt.com`.

--- a/services/code-for-boston/kustomization.yaml
+++ b/services/code-for-boston/kustomization.yaml
@@ -12,3 +12,9 @@ resources:
   - leantime/deployment.yaml
   - leantime/service.yaml
   - leantime/ingress.yaml
+  - mongodb/pvc.yaml
+  - mongodb/deployment.yaml
+  - mongodb/service.yaml
+  - wekan/deployment.yaml
+  - wekan/service.yaml
+  - wekan/ingress.yaml

--- a/services/code-for-boston/mongodb/deployment.yaml
+++ b/services/code-for-boston/mongodb/deployment.yaml
@@ -1,0 +1,41 @@
+# Dedicated MongoDB for Wekan only - nothing else in this cluster uses
+# Mongo, so this doesn't join the shared Postgres cluster pattern used
+# elsewhere. No auth configured: it's only reachable in-cluster via the
+# ClusterIP Service below, never exposed through an Ingress.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wekan-mongo
+  namespace: code-for-boston
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: wekan-mongo
+  template:
+    metadata:
+      labels:
+        app: wekan-mongo
+    spec:
+      containers:
+        - name: mongo
+          image: mongo:7
+          command: ["mongod", "--storageEngine=wiredTiger"]
+          ports:
+            - containerPort: 27017
+          volumeMounts:
+            - name: data
+              mountPath: /data/db
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: wekan-mongo-data

--- a/services/code-for-boston/mongodb/pvc.yaml
+++ b/services/code-for-boston/mongodb/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: wekan-mongo-data
+  namespace: code-for-boston
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/services/code-for-boston/mongodb/service.yaml
+++ b/services/code-for-boston/mongodb/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wekan-mongo
+  namespace: code-for-boston
+spec:
+  selector:
+    app: wekan-mongo
+  ports:
+    - port: 27017
+      targetPort: 27017

--- a/services/code-for-boston/wekan/deployment.yaml
+++ b/services/code-for-boston/wekan/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: wekan
+  namespace: code-for-boston
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: wekan
+  template:
+    metadata:
+      labels:
+        app: wekan
+    spec:
+      containers:
+        - name: wekan
+          image: wekanteam/wekan:v9.80
+          ports:
+            - containerPort: 8080
+              name: http
+          env:
+            - name: MONGO_URL
+              value: mongodb://wekan-mongo:27017/wekan
+            - name: ROOT_URL
+              value: https://wekan.labmatt.com
+            - name: PORT
+              value: "8080"
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"

--- a/services/code-for-boston/wekan/ingress.yaml
+++ b/services/code-for-boston/wekan/ingress.yaml
@@ -1,0 +1,22 @@
+# wekan.labmatt.com is routed through the Pangolin tunnel (see
+# infrastructure/cloudflare/opentofu tunnel_hostnames and
+# infrastructure/tunnel/README.md) so volunteers can reach it from the
+# open internet.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wekan
+  namespace: code-for-boston
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: wekan.labmatt.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: wekan
+                port:
+                  number: 8080

--- a/services/code-for-boston/wekan/service.yaml
+++ b/services/code-for-boston/wekan/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: wekan
+  namespace: code-for-boston
+spec:
+  selector:
+    app: wekan
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
## What

Deploys [Wekan](https://wekan.fi) (Trello-style kanban) into the
`code-for-boston` namespace, for a side-by-side trial with Leantime (see
the `leantime-trial` PR) to get volunteer feedback on which fits better.

Follows the `services/<tenant>` convention from #120: Wekan and its
dedicated MongoDB land as sibling components under
`services/code-for-boston`, next to `postgres/`. This is independent of
the Leantime PR — both branches add the tenant's `namespace.yaml` /
`kustomization.yaml` / `README.md` on top of `main` separately, so
whichever merges second will need a small (mechanical) merge conflict
resolved on those shared files.

- Wekan needs MongoDB, not the shared Postgres cluster used elsewhere in
  this repo, so it gets its own single-instance Mongo, reachable only
  in-cluster.
- Exposed publicly via Pangolin at `wekan.labmatt.com`
  (`tunnel_hostnames` in the Cloudflare DNS module for the DNS record,
  `infrastructure/tunnel/blueprints/wekan.yaml` for the Pangolin
  resource). No SSO and no access rules on the blueprint - it's fully
  open, since Wekan does its own registration/auth (first user to
  register becomes admin). Applying the blueprint is still a manual
  dashboard step per `infrastructure/tunnel/blueprints/README.md`.

## Why

Comparing Leantime and Wekan head-to-head with actual volunteer usage
beats guessing which project-management tool fits better up front.

## Deploy

See `services/code-for-boston/README.md` for the full apply order,
including running `tofu apply` for the DNS change and applying the
Pangolin blueprint per its README.
