### PR TITLE
Set HelmRelease.spec.timeout for kube-prometheus-stack (#37)

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -8,6 +8,7 @@ metadata:
   namespace: observability
 spec:
   interval: 30m
+  timeout: 15m
   releaseName: kube-prometheus-stack
   chart:
     spec:


### PR DESCRIPTION
## What changed

Sets `HelmRelease.spec.timeout: 15m` on `kube-prometheus-stack`, up from
the 5m default.

## Why

Part 1 of #37. Investigation (see the #37 comment) traced the #31/#36
incident to **etcd overload during mass pod churn** from the
84.5.0→88.5.4 chart-major bump, not node resource pressure - every node,
including the one hosting etcd, failed to renew its kubelet lease under
etcd request timeouts, which is what flipped them `NotReady`. 5m wasn't
enough headroom for that upgrade, and the timed-out upgrade's automatic
rollback then also timed out, compounding the churn instead of settling
it.

`PodDisruptionBudget`s for Grafana/Prometheus/Alertmanager were
considered and dropped from this PR: each runs a single replica today, so
`minAvailable: 1` wouldn't bound disruption, it would block voluntary
eviction (node drains, etc.) outright with nothing to fail over to.
Giving them real replicas is blocked on #13 (RWO-enforcing storage) for
Grafana specifically; tracking replicas + PDBs as a follow-up to do
collectively across Prometheus/Alertmanager/Grafana/the arr stack once
that lands.
