### PR TITLE
Lower kube-prometheus-stack remediation retries to 1 (#37)

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -25,10 +25,10 @@ spec:
         name: prometheus-community
   install:
     remediation:
-      retries: 3
+      retries: 1
   upgrade:
     remediation:
-      retries: 3
+      retries: 1
   values:
     prometheus:
       ingress:


### PR DESCRIPTION
## What changed

Lowers `install.remediation.retries` and `upgrade.remediation.retries`
from 3 to 1 on `kube-prometheus-stack`.

## Why

Follow-up to #48. Bumping `spec.timeout` to 15m without touching
`retries: 3` pushed the worst-case fully-automated upgrade/rollback churn
from ~40m up to ~2h (4 total attempts x (15m upgrade + 15m rollback)) -
working against the actual point of the timeout fix, which was less
sustained churn during a bad rollout, not more of it.

Auto-rollback stays on (retries: 1 keeps one automatic retry-and-rollback
cycle for a transient failure), it just no longer has room to compound
for hours before a human would need to step in - worst case is now
capped at ~1h.
