### PR TITLE
Cut cert-manager over to Flux (#15)

### DIFF
--- a/clusters/eye-of-michael/flux-system/cert-manager.yaml
+++ b/clusters/eye-of-michael/flux-system/cert-manager.yaml
@@ -1,0 +1,17 @@
+# Hand-authored, unlike gotk-components.yaml/gotk-sync.yaml (see README.md)
+# - one Kustomization per top-level directory category, per #15. Fourth
+# cutover, after observability, database, and storage.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: cert-manager
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/cert-manager
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -6,3 +6,4 @@ resources:
   - observability.yaml
   - database.yaml
   - storage.yaml
+  - cert-manager.yaml

--- a/infrastructure/kubernetes/cert-manager/README.md
+++ b/infrastructure/kubernetes/cert-manager/README.md
@@ -12,15 +12,15 @@ Create one at: Cloudflare Dashboard → My Profile → API Tokens → Create Tok
 
 ## Installation
 
-### 1. Create namespace
+`namespace.yaml`, `cluster-issuer.yaml`, and `cert-manager` itself are all
+Flux-managed (see below) - the only imperative step left is the secret,
+since it's deliberately not tracked in git.
 
-```bash
-kubectl apply -f infrastructure/kubernetes/cert-manager/namespace.yaml
-```
+### 1. Create Cloudflare API token secret
 
-### 2. Create Cloudflare API token secret
-
-This secret is not tracked in git and must be created imperatively:
+The namespace must exist first if this is a fresh cluster (Flux will
+create it on first reconcile, or apply `namespace.yaml` by hand to unblock
+the secret sooner):
 
 ```bash
 kubectl create secret generic cloudflare-api-token \
@@ -28,24 +28,15 @@ kubectl create secret generic cloudflare-api-token \
   --from-literal=api-token=<your-cloudflare-api-token>
 ```
 
-### 3. Install cert-manager
+### 2. cert-manager and the ClusterIssuers
 
-```bash
-helm repo add jetstack https://charts.jetstack.io
-helm repo update
-
-helm install cert-manager jetstack/cert-manager \
-  -n cert-manager \
-  -f infrastructure/kubernetes/cert-manager/values.yaml
-```
-
-### 4. Apply ClusterIssuers
+`cert-manager` is Flux-managed (`helmrelease.yaml`, see
+[../../../clusters/eye-of-michael/README.md](../../../clusters/eye-of-michael/README.md))
+- editing `helmrelease.yaml`'s `spec.values` and merging to `main` is the
+deploy step; there's no `helm install`/`helm upgrade` to run by hand any
+more. `cluster-issuer.yaml` is Flux-managed the same way.
 
 Two issuers are provided: `letsencrypt-cloudflare` (production) and `letsencrypt-cloudflare-staging` (staging). Use staging when testing to avoid hitting Let's Encrypt rate limits.
-
-```bash
-kubectl apply -f infrastructure/kubernetes/cert-manager/cluster-issuer.yaml
-```
 
 Verify both issuers are ready:
 

--- a/infrastructure/kubernetes/cert-manager/helmrelease.yaml
+++ b/infrastructure/kubernetes/cert-manager/helmrelease.yaml
@@ -1,0 +1,29 @@
+# Migrated from a manually-run `helm install` (see README.md for the old
+# imperative steps) as part of #15 - Flux now owns this release. Values
+# below are unchanged from values.yaml; only the wrapper is new. Chart
+# pinned to the already-deployed version so this is a no-op cutover.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: cert-manager
+  namespace: cert-manager
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: cert-manager
+  chart:
+    spec:
+      chart: cert-manager
+      version: "v1.20.2"
+      sourceRef:
+        kind: HelmRepository
+        name: jetstack
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    crds:
+      enabled: true

--- a/infrastructure/kubernetes/cert-manager/helmrelease.yaml
+++ b/infrastructure/kubernetes/cert-manager/helmrelease.yaml
@@ -1,7 +1,8 @@
-# Migrated from a manually-run `helm install` (see README.md for the old
-# imperative steps) as part of #15 - Flux now owns this release. Values
-# below are unchanged from values.yaml; only the wrapper is new. Chart
-# pinned to the already-deployed version so this is a no-op cutover.
+# Migrated from a manually-run `helm install` (see git history for the old
+# imperative steps in README.md) as part of #15 - Flux now owns this
+# release. Values below are unchanged from values.yaml; only the wrapper is
+# new. Chart pinned to the already-deployed version so this is a no-op
+# cutover.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/infrastructure/kubernetes/cert-manager/helmrelease.yaml
+++ b/infrastructure/kubernetes/cert-manager/helmrelease.yaml
@@ -1,5 +1,3 @@
-# Flux owns this release. Chart pinned to the already-deployed version so
-# this is a no-op cutover.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/infrastructure/kubernetes/cert-manager/helmrelease.yaml
+++ b/infrastructure/kubernetes/cert-manager/helmrelease.yaml
@@ -1,8 +1,5 @@
-# Migrated from a manually-run `helm install` (see git history for the old
-# imperative steps in README.md) as part of #15 - Flux now owns this
-# release. Values below are unchanged from values.yaml; only the wrapper is
-# new. Chart pinned to the already-deployed version so this is a no-op
-# cutover.
+# Flux owns this release. Chart pinned to the already-deployed version so
+# this is a no-op cutover.
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
 metadata:

--- a/infrastructure/kubernetes/cert-manager/helmrepository.yaml
+++ b/infrastructure/kubernetes/cert-manager/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: jetstack
+  namespace: cert-manager
+spec:
+  interval: 1h
+  url: https://charts.jetstack.io

--- a/infrastructure/kubernetes/cert-manager/kustomization.yaml
+++ b/infrastructure/kubernetes/cert-manager/kustomization.yaml
@@ -1,0 +1,13 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/cert-manager.yaml
+# for the Kustomization CR that reconciles this path, and #15 for the
+# rollout plan this cutover is part of.
+#
+# The `cloudflare-api-token` Secret (see README.md) is created imperatively
+# and intentionally not listed here - it stays untouched by prune.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - cluster-issuer.yaml


### PR DESCRIPTION
Fourth Flux cutover under #15, after observability, database, and storage.

## What changed

`cert-manager` is currently installed by hand (`helm install cert-manager
jetstack/cert-manager -f values.yaml`, per README.md) at `v1.20.2`. This
converts it to a Flux `HelmRelease`, pinned to that same already-deployed
version so the cutover itself is a no-op:

- `helmrepository.yaml` - new `HelmRepository` for `jetstack` (mirrors the
  `prometheus-community` one added for observability).
- `helmrelease.yaml` - `HelmRelease` wrapping the existing `values.yaml`
  content (`crds.enabled: true`) unchanged, `releaseName: cert-manager` so
  helm-controller picks up the existing Helm release rather than
  installing a second one. `timeout: 15m` / `remediation.retries: 1`,
  matching the settings #48/#49 established for kube-prometheus-stack.
- `kustomization.yaml` - lists `namespace.yaml`, the two new Flux
  resources, and the existing `cluster-issuer.yaml`. The imperatively
  created `cloudflare-api-token` Secret (see README.md) is deliberately
  left out so `prune: true` doesn't touch it.
- `clusters/eye-of-michael/flux-system/cert-manager.yaml` - the
  hand-authored Flux `Kustomization` CR, registered in that directory's
  `kustomization.yaml`.

## Why this one's riskier than the previous three cutovers

cert-manager owns cluster-wide `ClusterIssuer`s and the admission webhook
every `Certificate`/`Issuer` apply goes through - a bad reconcile here has
wider blast radius than observability/database/storage. Mitigated by:
pinning the exact live chart version (no functional change, not a version
bump), reusing the existing release name/namespace so Helm sees a
same-state upgrade rather than a fresh install, and the timeout/retries
settings already proven under load on kube-prometheus-stack.

## Verification

- `kubectl apply --dry-run=server -k infrastructure/kubernetes/cert-manager`:
  namespace and both `ClusterIssuer`s `unchanged`, only the new
  `HelmRelease`/`HelmRepository` show as `created`.
- `kubectl apply --dry-run=server -k clusters/eye-of-michael/flux-system`
  clean.
- `kubeconform -strict` (same invocation as `pr-validate.yml`, including
  the CRDs-catalog schema location) - all 7 resources valid.

Will watch the live reconcile after merge and confirm the existing
`ClusterIssuer`s stay `Ready` and no cert renewals are disrupted before
closing this out.