### PR TITLE
Cut ingress-nginx over to Flux (#15)

### DIFF
--- a/clusters/eye-of-michael/flux-system/ingress.yaml
+++ b/clusters/eye-of-michael/flux-system/ingress.yaml
@@ -1,0 +1,17 @@
+# Hand-authored, unlike gotk-components.yaml/gotk-sync.yaml (see README.md)
+# - one Kustomization per top-level directory category, per #15. Fifth
+# cutover, after observability, database, storage, and cert-manager.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ingress
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/ingress
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -7,3 +7,4 @@ resources:
   - database.yaml
   - storage.yaml
   - cert-manager.yaml
+  - ingress.yaml

--- a/infrastructure/kubernetes/ingress/helmrelease.yaml
+++ b/infrastructure/kubernetes/ingress/helmrelease.yaml
@@ -1,0 +1,44 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: ingress-nginx
+  chart:
+    spec:
+      chart: ingress-nginx
+      version: "4.14.3"
+      sourceRef:
+        kind: HelmRepository
+        name: ingress-nginx
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    controller:
+      # Run on control plane nodes using talos host network
+      hostNetwork: true
+
+      # Only run on control plane nodes
+      nodeSelector:
+        node-role.kubernetes.io/control-plane: ""
+
+      # Tolerate control plane taints so pods can schedule there
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Exists
+          effect: NoSchedule
+
+      # Ensures one runs on each control plane node
+      kind: DaemonSet
+
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi

--- a/infrastructure/kubernetes/ingress/helmrepository.yaml
+++ b/infrastructure/kubernetes/ingress/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+spec:
+  interval: 1h
+  url: https://kubernetes.github.io/ingress-nginx

--- a/infrastructure/kubernetes/ingress/kustomization.yaml
+++ b/infrastructure/kubernetes/ingress/kustomization.yaml
@@ -1,0 +1,13 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/ingress.yaml for
+# the Kustomization CR that reconciles this path, and #15 for the rollout
+# plan this cutover is part of.
+#
+# test-ingress.yaml is a manual smoke-test manifest (hello-world app) with
+# no live resources on the cluster right now - deliberately left out so
+# this cutover doesn't deploy it.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - helmrepository.yaml
+  - helmrelease.yaml

--- a/infrastructure/kubernetes/ingress/namespace.yaml
+++ b/infrastructure/kubernetes/ingress/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ingress-nginx
+  labels:
+    # ingress-nginx-controller uses hostNetwork/hostPort (see
+    # helmrelease.yaml) - baseline/restricted PodSecurity would block it.
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
Fifth Flux cutover under #15, after observability, database, storage, and
cert-manager.

## What changed

`ingress-nginx` is currently installed by hand (`helm install/upgrade` into
the `ingress-nginx` namespace, chart `4.14.3`) - note the live namespace
doesn't match this directory's name (`ingress`), pre-existing drift, not
something this PR fixes. Converts it to a Flux `HelmRelease`, pinned to
that same already-deployed version so the cutover itself is a no-op:

- `namespace.yaml` - matches the live namespace exactly, including its
  `pod-security.kubernetes.io/enforce: privileged` labels. Those aren't
  new: the controller runs with `hostNetwork`/`hostPort` (see
  `helmrelease.yaml`), which only `privileged` PodSecurity allows. A
  dry-run without these labels showed `configured` (would overwrite them)
  instead of `unchanged` - confirmed via `kubectl get namespace -o yaml`
  against live state and fixed before this PR.
- `helmrepository.yaml` - new `HelmRepository` for `ingress-nginx`.
- `helmrelease.yaml` - values transcribed byte-for-byte from the existing
  `values.yaml`. `releaseName: ingress-nginx` so helm-controller adopts
  the existing release. `timeout: 15m` / `remediation.retries: 1`, same as
  the other cutovers.
- `clusters/eye-of-michael/flux-system/ingress.yaml` - the hand-authored
  Flux `Kustomization` CR.

`test-ingress.yaml` (a manual hello-world smoke-test manifest) has no live
resources on the cluster right now and is deliberately left out of the new
`kustomization.yaml` so this cutover doesn't newly deploy it.

## Why this one's the riskiest cutover so far

`ingress-nginx` is the actual traffic path for every `*.labmatt.com`
service, running as a `hostNetwork` DaemonSet across all 3 control-plane
nodes (`maxUnavailable: 1` on rolling updates). Mitigated the same way as
cert-manager: pinning the exact live chart version and values so Helm
renders an identical manifest and the DaemonSet's pod template hash
doesn't change - no rollout should be triggered at all, not even a
brief per-node cycle.

## Verification

- `kubectl apply --dry-run=server -k infrastructure/kubernetes/ingress`:
  namespace `unchanged`, only the new `HelmRelease`/`HelmRepository` show
  as `created`.
- `kubectl apply --dry-run=server -k clusters/eye-of-michael/flux-system`
  clean.
- `kubeconform -strict` (same invocation as `pr-validate.yml`) - all 5
  resources valid.
- Diffed `helmrelease.yaml`'s values block against `values.yaml` - byte-
  for-byte identical.

Will watch the live reconcile after merge and confirm the DaemonSet pods
are untouched (no restart) and all `*.labmatt.com` ingresses stay
reachable before closing this out.