### PR TITLE
Cut ci-cd over to Flux (#15)

### DIFF
--- a/clusters/eye-of-michael/flux-system/ci-cd.yaml
+++ b/clusters/eye-of-michael/flux-system/ci-cd.yaml
@@ -1,0 +1,18 @@
+# Hand-authored, unlike gotk-components.yaml/gotk-sync.yaml (see README.md)
+# - one Kustomization per top-level directory category, per #15. Sixth
+# cutover, after observability, database, storage, cert-manager, and
+# ingress.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ci-cd
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/ci-cd
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - storage.yaml
   - cert-manager.yaml
   - ingress.yaml
+  - ci-cd.yaml

--- a/infrastructure/kubernetes/ci-cd/kustomization.yaml
+++ b/infrastructure/kubernetes/ci-cd/kustomization.yaml
@@ -1,0 +1,12 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/ci-cd.yaml for the
+# Kustomization CR that reconciles this path, and #15 for the rollout plan
+# this cutover is part of.
+#
+# The renovate-github-token Secret (see renovate/README.md) is created
+# imperatively and intentionally not listed here - it stays untouched by
+# prune.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - renovate/cronjob.yaml

--- a/infrastructure/kubernetes/ci-cd/renovate/README.md
+++ b/infrastructure/kubernetes/ci-cd/renovate/README.md
@@ -18,10 +18,11 @@ cluster-side pieces that run the bot itself.
   `MattClarke131/project-seeds`
 
 ## Apply
-```
-kubectl apply -f infrastructure/kubernetes/ci-cd/namespace.yaml
-kubectl apply -f infrastructure/kubernetes/ci-cd/renovate/cronjob.yaml
-```
+
+This namespace and the CronJob are Flux-managed (see
+[../../../../clusters/eye-of-michael/README.md](../../../../clusters/eye-of-michael/README.md))
+- editing `cronjob.yaml` and merging to `main` is the deploy step; there's
+no `kubectl apply` to run by hand any more.
 
 ## GitHub token
 


### PR DESCRIPTION
Sixth Flux cutover under #15, after observability, database, storage,
cert-manager, and ingress.

## What changed

`ci-cd` (the Renovate `CronJob`) is currently applied by hand
(`kubectl apply -f namespace.yaml` + `kubectl apply -f
renovate/cronjob.yaml`, per renovate/README.md). No Helm chart involved -
just plain manifests, same shape as the `database` cutover.

- `kustomization.yaml` - lists `namespace.yaml` and `renovate/cronjob.yaml`.
  The imperatively created `renovate-github-token` Secret (see
  renovate/README.md) is deliberately left out so `prune: true` doesn't
  touch it.
- `clusters/eye-of-michael/flux-system/ci-cd.yaml` - the hand-authored
  Flux `Kustomization` CR.
- `renovate/README.md` - replaced the manual `kubectl apply` steps with a
  pointer to the Flux deploy flow (merge to `main`), same pattern as the
  observability/cert-manager README updates.

## Why this one's low risk

No Helm chart, no DaemonSet, nothing serving live traffic. The `CronJob`
only runs once a day; a bad reconcile here at worst means Renovate skips a
run, not any user-facing disruption.

## Verification

- `kubectl apply --dry-run=server -k infrastructure/kubernetes/ci-cd`:
  both `namespace/ci-cd` and `cronjob.batch/renovate` show `unchanged`.
- `kubectl apply --dry-run=server -k clusters/eye-of-michael/flux-system`
  clean.
- `kubeconform -strict` (same invocation as `pr-validate.yml`) - all 4
  resources valid.

Will confirm the Kustomization reconciles clean after merge before closing
this out.