### PR TITLE
Cut tunnel over to Flux (#15)

### DIFF
--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -10,3 +10,4 @@ resources:
   - ingress.yaml
   - ci-cd.yaml
   - intel-gpu-plugin.yaml
+  - tunnel.yaml

--- a/clusters/eye-of-michael/flux-system/tunnel.yaml
+++ b/clusters/eye-of-michael/flux-system/tunnel.yaml
@@ -1,0 +1,19 @@
+# Hand-authored, unlike gotk-components.yaml/gotk-sync.yaml (see README.md)
+# - one Kustomization per top-level directory category, per #15. Eighth
+# cutover, after observability, database, storage, cert-manager, ingress,
+# ci-cd, and intel-gpu-plugin - last of the infrastructure/kubernetes
+# categories.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: tunnel
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/tunnel
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/infrastructure/kubernetes/tunnel/kustomization.yaml
+++ b/infrastructure/kubernetes/tunnel/kustomization.yaml
@@ -1,0 +1,11 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/tunnel.yaml for
+# the Kustomization CR that reconciles this path, and #15 for the
+# rollout plan this cutover is part of.
+#
+# The newt-auth Secret is created imperatively and intentionally not
+# listed here - it stays untouched by prune.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - newt/deployment.yaml

--- a/infrastructure/kubernetes/tunnel/namespace.yaml
+++ b/infrastructure/kubernetes/tunnel/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: tunnel

--- a/infrastructure/kubernetes/tunnel/newt/deployment.yaml
+++ b/infrastructure/kubernetes/tunnel/newt/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
       - name: newt
-        image: fosrl/newt:latest
+        image: fosrl/newt:1.15.0
         env:
         - name: PANGOLIN_ENDPOINT
           valueFrom:


### PR DESCRIPTION
Eighth Flux cutover (of the per-category rollout tracked in #15), after
observability, database, storage, cert-manager, ingress, ci-cd, and
intel-gpu-plugin - the last of the `infrastructure/kubernetes/*`
categories.

Riskiest of this batch: `newt` is a single-replica Deployment with no
redundancy, and it's the actual external ingress path (the Pangolin
tunnel) - if this cutover goes wrong, every `*.labmatt.com` service
becomes unreachable from outside.

Adds `infrastructure/kubernetes/tunnel/namespace.yaml` (bare, matching
the live namespace - no pod-security labels needed, unlike
cert-manager/ingress-nginx) and
`infrastructure/kubernetes/tunnel/kustomization.yaml` (namespace +
`newt/deployment.yaml`; the `newt-auth` Secret stays out, created
imperatively, untouched by prune), plus a hand-authored Flux
`Kustomization` CR in `clusters/eye-of-michael/flux-system/`.

Pre-existing, not touched by this PR: `newt`'s image is unpinned
(`fosrl/newt:latest`), so Renovate can't track it. Worth a follow-up.

Verified pre-merge:
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/tunnel` -> `deployment.apps/newt unchanged`; namespace's "configured" is only the missing-last-applied-annotation warning, confirmed via `kubectl diff` as zero actual field drift
- Flux `Kustomization` CR dry-run applies cleanly
- `kubeconform -strict` clean with CI's exact flags