### PR TITLE
Cut metrics-server over to Flux HelmRelease (#15)

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -26,6 +26,12 @@ git add kube-prometheus-stack/prometheus-targets-configmap.yaml
 git commit
 ```
 
+### Metrics Server
+
+`metrics-server` is Flux-managed (`metrics-server/helmrelease.yaml`) -
+editing `helmrelease.yaml`'s `spec.values` and merging to `main` is the
+deploy step; there's no `helm upgrade` to run by hand any more.
+
 ### Loki + Promtail
 1. Install Loki
 ```bash

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -2,10 +2,10 @@
 # for the Kustomization CR that reconciles this path, and #15 for the
 # rollout plan this is the first cutover of.
 #
-# json-exporter/, loki/, metrics-server/ are Helm charts still installed by
-# hand (`helm install/upgrade`, per README.md) - not covered by this
+# json-exporter/, loki/ are Helm charts still installed by hand
+# (`helm install/upgrade`, per README.md) - not covered by this
 # Kustomization. Converting them to HelmReleases is follow-up work, same as
-# kube-prometheus-stack was here.
+# kube-prometheus-stack and metrics-server were here.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -23,6 +23,8 @@ resources:
   - kube-prometheus-stack/prometheus-targets-configmap.yaml
   - kube-prometheus-stack/helmrepository.yaml
   - kube-prometheus-stack/helmrelease.yaml
+  - metrics-server/helmrepository.yaml
+  - metrics-server/helmrelease.yaml
   - ntfy-alertmanager/configmap.yaml
   - ntfy-alertmanager/deployment.yaml
   - ntfy/deployment.yaml

--- a/infrastructure/kubernetes/observability/metrics-server/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/metrics-server/helmrelease.yaml
@@ -1,0 +1,28 @@
+# Migrated from a manually-run `helm install` (see git history for the old
+# values.yaml) as part of #15 - Flux now owns this release. Values below are
+# unchanged from that file; only the wrapper is new.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: metrics-server
+  namespace: observability
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: metrics-server
+  chart:
+    spec:
+      chart: metrics-server
+      version: "3.13.0"
+      sourceRef:
+        kind: HelmRepository
+        name: metrics-server
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    args:
+      - --kubelet-insecure-tls

--- a/infrastructure/kubernetes/observability/metrics-server/helmrepository.yaml
+++ b/infrastructure/kubernetes/observability/metrics-server/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: metrics-server
+  namespace: observability
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/metrics-server/


### PR DESCRIPTION
Converts `metrics-server` from a manual `helm install` to a Flux
`HelmRelease`, same pattern as `kube-prometheus-stack`'s cutover
(within the already-Flux-managed `observability` category, so no new
Flux `Kustomization` CR needed - just adds two resources to the
existing one).

Chart pinned to the already-deployed version (`3.13.0`) and values
transcribed byte-for-byte from the live release
(`helm get values metrics-server -n observability`), so this should be
a no-op adoption of the existing Helm release, not a new deploy.

`json-exporter`/`loki` remain manually Helm-installed - same follow-up
scope as before, just narrower now.

Verified pre-merge:
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/observability` -> `helmrelease.helm.toolkit.fluxcd.io/metrics-server created` and `helmrepository.../metrics-server created` (expected - these CRs don't exist yet), nothing else in the category shows a diff
- `kubeconform -strict` clean with CI's exact flags