### PR TITLE
Cut promtail over to Flux HelmRelease (#15)

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -33,6 +33,11 @@ editing `helmrelease.yaml`'s `spec.values` and merging to `main` is the
 deploy step; there's no `helm upgrade` to run by hand any more.
 
 ### Loki + Promtail
+
+`promtail` is Flux-managed (`promtail/helmrelease.yaml`) - editing
+`helmrelease.yaml`'s `spec.values` and merging to `main` is the deploy
+step; there's no `helm upgrade` to run by hand any more.
+
 1. Install Loki
 ```bash
 cd loki
@@ -41,14 +46,7 @@ helm install loki grafana/loki \
   --values values.yaml
 ```
 
-2. Install Promtail
-```bash
-helm install promtail grafana/promtail \
-  --namespace observability \
-  --set "config.clients[0].url=http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push"
-```
-
-3. Add Loki datasource to Grafana
+2. Add Loki datasource to Grafana
    - URL: `http://loki-gateway.observability.svc.cluster.local`
    - Configuration → Data Sources → Add Loki
 

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -5,7 +5,7 @@
 # json-exporter/, loki/ are Helm charts still installed by hand
 # (`helm install/upgrade`, per README.md) - not covered by this
 # Kustomization. Converting them to HelmReleases is follow-up work, same as
-# kube-prometheus-stack and metrics-server were here.
+# kube-prometheus-stack, metrics-server, and promtail were here.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -25,6 +25,8 @@ resources:
   - kube-prometheus-stack/helmrelease.yaml
   - metrics-server/helmrepository.yaml
   - metrics-server/helmrelease.yaml
+  - promtail/helmrepository.yaml
+  - promtail/helmrelease.yaml
   - ntfy-alertmanager/configmap.yaml
   - ntfy-alertmanager/deployment.yaml
   - ntfy/deployment.yaml

--- a/infrastructure/kubernetes/observability/promtail/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/promtail/helmrelease.yaml
@@ -1,0 +1,29 @@
+# Migrated from a manually-run `helm install` (see README.md's git history
+# for the old --set invocation) as part of #15 - Flux now owns this
+# release. Values below are transcribed from `helm get values promtail`,
+# not the README's --set flag (chart-version-dependent flag naming).
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: promtail
+  namespace: observability
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: promtail
+  chart:
+    spec:
+      chart: promtail
+      version: "6.17.1"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    config:
+      lokiAddress: http://loki-gateway.observability.svc.cluster.local/loki/api/v1/push

--- a/infrastructure/kubernetes/observability/promtail/helmrepository.yaml
+++ b/infrastructure/kubernetes/observability/promtail/helmrepository.yaml
@@ -1,0 +1,12 @@
+# Shared with loki's eventual HelmRelease (same chart source,
+# grafana.github.io/helm-charts) - defined here since promtail is
+# cutting over first; loki's cutover will reference this by name rather
+# than redefining it.
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: grafana
+  namespace: observability
+spec:
+  interval: 1h
+  url: https://grafana.github.io/helm-charts


### PR DESCRIPTION
Converts `promtail` from a manual `helm install` to a Flux `HelmRelease`,
same pattern as `kube-prometheus-stack`/`metrics-server`'s cutovers -
within the already-Flux-managed `observability` category, so no new
Flux `Kustomization` CR needed.

First of the three remaining observability charts (of
`json-exporter`/`loki`/`promtail`), chosen lowest-risk first: DaemonSet,
no persistent state, no Secrets.

Also adds a `grafana` `HelmRepository` (`grafana.github.io/helm-charts`)
- shared source for `loki`'s eventual cutover too, so that PR will
reference this by name rather than redefining it.

Chart pinned to the already-deployed version (`6.17.1`) and values
transcribed from `helm get values promtail` (not the README's old
`--set` flag, which is chart-version-dependent flag naming) - should be
a no-op adoption of the existing release.

Verified pre-merge:
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/observability` -> only `helmrelease.../promtail created` and `helmrepository.../grafana created` (expected, new CRs), nothing else in the category shows a diff
- `kubeconform -strict` clean with CI's exact flags