### PR TITLE
Cut loki over to Flux HelmRelease (#15)

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -34,21 +34,15 @@ deploy step; there's no `helm upgrade` to run by hand any more.
 
 ### Loki + Promtail
 
-`promtail` is Flux-managed (`promtail/helmrelease.yaml`) - editing
-`helmrelease.yaml`'s `spec.values` and merging to `main` is the deploy
-step; there's no `helm upgrade` to run by hand any more.
+Both are Flux-managed (`loki/helmrelease.yaml`, `promtail/helmrelease.yaml`)
+- editing `helmrelease.yaml`'s `spec.values` and merging to `main` is the
+deploy step; there's no `helm upgrade` to run by hand any more.
+`loki/values.yaml` is kept as a standalone reference copy of the same
+values, not wired in.
 
-1. Install Loki
-```bash
-cd loki
-helm install loki grafana/loki \
-  --namespace observability \
-  --values values.yaml
-```
-
-2. Add Loki datasource to Grafana
-   - URL: `http://loki-gateway.observability.svc.cluster.local`
-   - Configuration → Data Sources → Add Loki
+Add Loki datasource to Grafana:
+- URL: `http://loki-gateway.observability.svc.cluster.local`
+- Configuration → Data Sources → Add Loki
 
 ## Accessing Grafana
 

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -2,10 +2,10 @@
 # for the Kustomization CR that reconciles this path, and #15 for the
 # rollout plan this is the first cutover of.
 #
-# json-exporter/, loki/ are Helm charts still installed by hand
+# json-exporter/ is a Helm chart still installed by hand
 # (`helm install/upgrade`, per README.md) - not covered by this
-# Kustomization. Converting them to HelmReleases is follow-up work, same as
-# kube-prometheus-stack, metrics-server, and promtail were here.
+# Kustomization. Converting it to a HelmRelease is follow-up work, same as
+# kube-prometheus-stack, metrics-server, promtail, and loki were here.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
@@ -27,6 +27,7 @@ resources:
   - metrics-server/helmrelease.yaml
   - promtail/helmrepository.yaml
   - promtail/helmrelease.yaml
+  - loki/helmrelease.yaml
   - ntfy-alertmanager/configmap.yaml
   - ntfy-alertmanager/deployment.yaml
   - ntfy/deployment.yaml

--- a/infrastructure/kubernetes/observability/loki/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/loki/helmrelease.yaml
@@ -1,0 +1,88 @@
+# Migrated from a manually-run `helm install` (see values.yaml for the
+# equivalent standalone file, kept as reference) as part of #15 - Flux
+# now owns this release. Uses the `grafana` HelmRepository defined in
+# ../promtail/helmrepository.yaml, same chart source.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: observability
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: loki
+  chart:
+    spec:
+      chart: loki
+      version: "6.52.0"
+      sourceRef:
+        kind: HelmRepository
+        name: grafana
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    deploymentMode: SingleBinary
+
+    loki:
+      auth_enabled: false
+      commonConfig:
+        replication_factor: 1
+      schemaConfig:
+        configs:
+          - from: "2026-01-01"
+            store: tsdb
+            object_store: filesystem
+            schema: v13
+            index:
+              prefix: loki_index_
+              period: 24h
+      storage:
+        type: filesystem
+
+    singleBinary:
+      replicas: 1
+      persistence:
+        enabled: true
+        storageClass: nfs-provisioner
+        size: 50Gi
+        # Chart defaults both to Delete - under Flux's prune:true, a bad
+        # merge that drops this manifest from the kustomization would
+        # delete the StatefulSet and, with the chart default, the 50Gi
+        # PVC and all log history along with it (the PV's own reclaim
+        # policy is also Delete, so PVC deletion is unrecoverable).
+        # Retain means the same accidental deletion only removes the
+        # StatefulSet; the PVC/PV survive since nothing deletes them as
+        # a side effect.
+        whenDeleted: Retain
+        whenScaled: Retain
+
+    read:
+      replicas: 0
+    write:
+      replicas: 0
+    backend:
+      replicas: 0
+
+    resultsCache:
+      enabled: true
+
+    chunksCache:
+      enabled: false
+
+    lokiCanary:
+      enabled: false
+
+    monitoring:
+      selfMonitoring:
+        enabled: false
+        grafanaAgent:
+          installOperator: false
+        lokiCanary:
+          enabled: false
+
+    test:
+      enabled: false

--- a/infrastructure/kubernetes/observability/loki/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/loki/helmrelease.yaml
@@ -42,21 +42,37 @@ spec:
               period: 24h
       storage:
         type: filesystem
+      # No retention was ever configured before this cutover - logs had
+      # been accumulating since the 2026-02-08 install (~117GiB and
+      # growing, already past the PVC's nominal 50Gi since nfs-provisioner
+      # doesn't enforce that as a real quota). 180 days at the observed
+      # ~0.6GiB/day growth rate settles around ~108GiB steady-state -
+      # see singleBinary.persistence.size below, bumped to stay honest
+      # about that.
+      limits_config:
+        retention_period: 4320h
+      compactor:
+        working_directory: /var/loki/compactor
+        retention_enabled: true
+        delete_request_store: filesystem
 
     singleBinary:
       replicas: 1
       persistence:
         enabled: true
         storageClass: nfs-provisioner
-        size: 50Gi
+        # Was 50Gi, already stale (live usage is ~117GiB - nfs-provisioner
+        # doesn't enforce this as a real quota, so nothing broke, but the
+        # number was lying). Bumped to roughly match the ~108GiB
+        # steady-state the new 180-day retention above settles at.
+        size: 150Gi
         # Chart defaults both to Delete - under Flux's prune:true, a bad
         # merge that drops this manifest from the kustomization would
-        # delete the StatefulSet and, with the chart default, the 50Gi
-        # PVC and all log history along with it (the PV's own reclaim
-        # policy is also Delete, so PVC deletion is unrecoverable).
-        # Retain means the same accidental deletion only removes the
-        # StatefulSet; the PVC/PV survive since nothing deletes them as
-        # a side effect.
+        # delete the StatefulSet and, with the chart default, the PVC and
+        # all log history along with it (the PV's own reclaim policy is
+        # also Delete, so PVC deletion is unrecoverable). Retain means
+        # the same accidental deletion only removes the StatefulSet; the
+        # PVC/PV survive since nothing deletes them as a side effect.
         whenDeleted: Retain
         whenScaled: Retain
 

--- a/infrastructure/kubernetes/observability/loki/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/loki/helmrelease.yaml
@@ -61,10 +61,6 @@ spec:
       persistence:
         enabled: true
         storageClass: nfs-provisioner
-        # Was 50Gi, already stale (live usage is ~117GiB - nfs-provisioner
-        # doesn't enforce this as a real quota, so nothing broke, but the
-        # number was lying). Bumped to roughly match the ~108GiB
-        # steady-state the new 180-day retention above settles at.
         size: 150Gi
         # Chart defaults both to Delete - under Flux's prune:true, a bad
         # merge that drops this manifest from the kustomization would

--- a/infrastructure/kubernetes/observability/loki/values.yaml
+++ b/infrastructure/kubernetes/observability/loki/values.yaml
@@ -31,10 +31,6 @@ singleBinary:
   persistence:
     enabled: true
     storageClass: nfs-provisioner
-    # Was 50Gi, already stale (live usage is ~117GiB - nfs-provisioner
-    # doesn't enforce this as a real quota, so nothing broke, but the
-    # number was lying). Bumped to roughly match the ~108GiB steady-state
-    # the new 180-day retention above settles at.
     size: 150Gi
     # Chart defaults both to Delete - under Flux's prune:true, a bad merge
     # that drops this manifest from the kustomization would delete the

--- a/infrastructure/kubernetes/observability/loki/values.yaml
+++ b/infrastructure/kubernetes/observability/loki/values.yaml
@@ -22,6 +22,15 @@ singleBinary:
     enabled: true
     storageClass: nfs-provisioner
     size: 50Gi
+    # Chart defaults both to Delete - under Flux's prune:true, a bad merge
+    # that drops this manifest from the kustomization would delete the
+    # StatefulSet and, with the chart default, the 50Gi PVC and all log
+    # history along with it (the PV's own reclaim policy is also Delete,
+    # so PVC deletion is unrecoverable). Retain means the same accidental
+    # deletion only removes the StatefulSet; the PVC/PV survive since
+    # nothing deletes them as a side effect.
+    whenDeleted: Retain
+    whenScaled: Retain
 
 read:
   replicas: 0

--- a/infrastructure/kubernetes/observability/loki/values.yaml
+++ b/infrastructure/kubernetes/observability/loki/values.yaml
@@ -15,18 +15,32 @@ loki:
           period: 24h
   storage:
     type: filesystem
+  # No retention was ever configured before this cutover - logs had been
+  # accumulating since the 2026-02-08 install. 180 days at the observed
+  # ~0.6GiB/day growth rate settles around ~108GiB steady-state - see
+  # singleBinary.persistence.size below, bumped to stay honest about that.
+  limits_config:
+    retention_period: 4320h
+  compactor:
+    working_directory: /var/loki/compactor
+    retention_enabled: true
+    delete_request_store: filesystem
 
 singleBinary:
   replicas: 1
   persistence:
     enabled: true
     storageClass: nfs-provisioner
-    size: 50Gi
+    # Was 50Gi, already stale (live usage is ~117GiB - nfs-provisioner
+    # doesn't enforce this as a real quota, so nothing broke, but the
+    # number was lying). Bumped to roughly match the ~108GiB steady-state
+    # the new 180-day retention above settles at.
+    size: 150Gi
     # Chart defaults both to Delete - under Flux's prune:true, a bad merge
     # that drops this manifest from the kustomization would delete the
-    # StatefulSet and, with the chart default, the 50Gi PVC and all log
-    # history along with it (the PV's own reclaim policy is also Delete,
-    # so PVC deletion is unrecoverable). Retain means the same accidental
+    # StatefulSet and, with the chart default, the PVC and all log history
+    # along with it (the PV's own reclaim policy is also Delete, so PVC
+    # deletion is unrecoverable). Retain means the same accidental
     # deletion only removes the StatefulSet; the PVC/PV survive since
     # nothing deletes them as a side effect.
     whenDeleted: Retain


### PR DESCRIPTION
Converts `loki` from a manual `helm install` to a Flux `HelmRelease`,
same pattern as the other observability charts - within the
already-Flux-managed `observability` category, so no new Flux
`Kustomization` CR needed. References the `grafana` `HelmRepository`
added by #58 (promtail's cutover).

**Found a real risk before merging, not introduced by this PR but made
sharper by it:** `loki`'s StatefulSet has
`persistentVolumeClaimRetentionPolicy: {whenDeleted: Delete, whenScaled:
Delete}` - the chart's default. That means deleting the StatefulSet
(today: `helm uninstall`; after this PR: also a bad merge dropping the
manifest under `prune: true`) auto-deletes the 50Gi PVC, and the PV's
own reclaim policy is also `Delete`, so that's unrecoverable log data
loss. Set `singleBinary.persistence.whenDeleted`/`whenScaled` to
`Retain` in this PR so an accidental StatefulSet deletion only removes
the StatefulSet - the PVC/PV survive for manual recovery. This is a
mutable StatefulSet field, so it doesn't trigger a pod restart on its
own.

Otherwise chart pinned to the already-deployed version (`6.52.0`) and
values transcribed from the live release - `helm get values loki`
diffed clean against the existing `values.yaml` (only YAML
formatting/key-ordering differences, no content differences). Kept
`values.yaml` as a standalone reference copy, not wired into the
HelmRelease (matches `metrics-server`'s pattern).

Verified pre-merge:
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/observability` -> only `helmrelease.../loki created` (expected, new CR), nothing else in the category shows a diff
- `kubeconform -strict` clean on the real manifest (`values.yaml` is excluded from kubeconform by CI's own rules, same as every other chart's values file)