### PR TITLE
Add CPU and memory pressure gauges to Proxmox overview dashboard

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -50,6 +50,40 @@ helm install loki grafana/loki \
    - URL: `http://loki-gateway.observability.svc.cluster.local`
    - Configuration → Data Sources → Add Loki
 
+## Dashboards
+
+Dashboard JSON lives in `dashboards/*.yaml` as ConfigMaps labeled
+`grafana_dashboard: "1"`; a sidecar in the Grafana pod watches for that
+label and loads/reloads dashboards automatically. Flux manages these
+files like everything else in this tree - merging to `main` is the
+deploy step.
+
+### Testing a dashboard change before merging
+
+Flux reconciles this whole directory, so a `kubectl apply` of a
+committed dashboard's ConfigMap gets reverted back to whatever's on
+`main` on Flux's next sync (harmless, but your test edits vanish
+without warning). The sidecar itself doesn't care who applied a
+ConfigMap or whether it's in git though - it just watches for the
+label. So test under a ConfigMap **Flux doesn't own**, by giving it a
+name that isn't committed to the repo:
+
+1. Copy the dashboard's YAML to a scratch file, then in that copy:
+   - rename `metadata.name` (e.g. `proxmox-overview` → `proxmox-overview-dev`)
+   - change the `grafana_folder` annotation to `"Dev"` so it doesn't
+     land next to the real dashboards
+   - change the embedded JSON's `uid` and `title` so it doesn't
+     collide with the real dashboard (e.g. `adnvjd7` → `adnvjd7-dev`,
+     `"Proxmox Overview"` → `"Proxmox Overview (dev)"`)
+2. `kubectl -n observability apply -f <scratch-file>` - the sidecar
+   picks it up within ~15s and it shows up in Grafana's "Dev" folder.
+   Flux never sees it, so it sits there untouched for as long as you
+   want, through as many edit/apply cycles as you need.
+3. Once you're happy, fold the changes into the real committed file
+   and open a PR as usual.
+4. `kubectl -n observability delete configmap proxmox-overview-dev`
+   (or whatever you named it) to clean up.
+
 ## Accessing Grafana
 
 Get the admin password:

--- a/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
@@ -82,7 +82,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
+            "w": 6,
             "x": 0,
             "y": 1
           },
@@ -155,8 +155,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
+            "w": 6,
+            "x": 6,
             "y": 1
           },
           "id": 2,
@@ -190,6 +190,152 @@ data:
             }
           ],
           "title": "Host CPU %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 1
+          },
+          "id": 3,
+          "options": {
+            "minVizWidth": 75,
+            "minVizHeight": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "100 * rate(node_pressure_cpu_waiting_seconds_total{job=\"node-exporter\", role=\"host\"}[5m])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Host CPU Pressure %",
+          "type": "gauge"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "id": 4,
+          "options": {
+            "minVizWidth": 75,
+            "minVizHeight": 75,
+            "orientation": "auto",
+            "reduceOptions": {
+              "values": false,
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": ""
+            },
+            "showThresholdLabels": false,
+            "showThresholdMarkers": true,
+            "sizing": "auto"
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "100 * rate(node_pressure_memory_waiting_seconds_total{job=\"node-exporter\", role=\"host\"}[5m])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Host Memory Pressure %",
           "type": "gauge"
         },
         {
@@ -1185,5 +1331,5 @@ data:
       "timezone": "browser",
       "title": "Proxmox Overview",
       "uid": "adnvjd7",
-      "version": 3
+      "version": 4
     }

--- a/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
@@ -82,7 +82,7 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
+            "w": 12,
             "x": 0,
             "y": 1
           },
@@ -155,8 +155,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 6,
+            "w": 12,
+            "x": 12,
             "y": 1
           },
           "id": 2,
@@ -200,11 +200,43 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
               },
               "mappings": [],
-              "max": 100,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -222,31 +254,31 @@ data:
                   }
                 ]
               },
-              "unit": "percent"
+              "unit": "percent",
+              "max": 100,
+              "min": 0
             },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
+            "w": 12,
             "x": 12,
-            "y": 1
+            "y": 10
           },
           "id": 3,
           "options": {
-            "minVizWidth": 75,
-            "minVizHeight": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "values": false,
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": ""
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
           "pluginVersion": "12.3.1",
           "targets": [
@@ -263,7 +295,20 @@ data:
             }
           ],
           "title": "Host CPU Pressure %",
-          "type": "gauge"
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 5,
+          "panels": [],
+          "title": "Host Pressure",
+          "type": "row"
         },
         {
           "datasource": {
@@ -273,11 +318,43 @@ data:
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
               },
               "mappings": [],
-              "max": 100,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -295,31 +372,31 @@ data:
                   }
                 ]
               },
-              "unit": "percent"
+              "unit": "percent",
+              "max": 100,
+              "min": 0
             },
             "overrides": []
           },
           "gridPos": {
             "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 1
+            "w": 12,
+            "x": 0,
+            "y": 10
           },
           "id": 4,
           "options": {
-            "minVizWidth": 75,
-            "minVizHeight": 75,
-            "orientation": "auto",
-            "reduceOptions": {
-              "values": false,
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": ""
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
             },
-            "showThresholdLabels": false,
-            "showThresholdMarkers": true,
-            "sizing": "auto"
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
           },
           "pluginVersion": "12.3.1",
           "targets": [
@@ -336,7 +413,7 @@ data:
             }
           ],
           "title": "Host Memory Pressure %",
-          "type": "gauge"
+          "type": "timeseries"
         },
         {
           "collapsed": false,
@@ -344,7 +421,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 9
+            "y": 18
           },
           "id": 10,
           "panels": [],
@@ -421,7 +498,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 10
+            "y": 19
           },
           "id": 11,
           "options": {
@@ -526,7 +603,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 10
+            "y": 19
           },
           "id": 12,
           "options": {
@@ -631,7 +708,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 27
           },
           "id": 13,
           "options": {
@@ -670,7 +747,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 26
+            "y": 35
           },
           "id": 14,
           "panels": [],
@@ -747,7 +824,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 27
+            "y": 36
           },
           "id": 15,
           "options": {
@@ -852,7 +929,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 27
+            "y": 36
           },
           "id": 16,
           "options": {
@@ -957,7 +1034,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 44
           },
           "id": 17,
           "options": {
@@ -996,7 +1073,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 43
+            "y": 52
           },
           "id": 18,
           "panels": [],
@@ -1073,7 +1150,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 44
+            "y": 53
           },
           "id": 19,
           "options": {
@@ -1178,7 +1255,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 44
+            "y": 53
           },
           "id": 20,
           "options": {
@@ -1283,7 +1360,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 61
           },
           "id": 21,
           "options": {
@@ -1331,5 +1408,5 @@ data:
       "timezone": "browser",
       "title": "Proxmox Overview",
       "uid": "adnvjd7",
-      "version": 4
+      "version": 6
     }


### PR DESCRIPTION
Adds two gauges to the Physical Hosts row: **Host CPU Pressure %** and **Host Memory Pressure %**, using node_exporter's PSI metrics (`node_pressure_cpu_waiting_seconds_total`, `node_pressure_memory_waiting_seconds_total`).

Usage % (already on the dashboard) shows how full CPU/RAM are, but not whether anything is actually stalled waiting on them — a host can be at 95% CPU busy and fine, or at 60% and thrashing behind a couple of hot tasks. PSI catches the latter case.

Existing 'Workload RAM Used %' and 'Host CPU %' gauges were narrowed from w=12 to w=6 to fit all four gauges (RAM used %, CPU %, CPU pressure %, memory pressure %) in one row per the original layout intent — one chart per metric, all three hosts (nicholas/livio/razlo) as gauge segments within it.

No node-exporter config changes needed: collector.pressure has been on by default since node_exporter v1.3.0, and I confirmed live against Prometheus that all three hosts are already emitting both metrics.

Pressure thresholds (yellow 5%, red 20%) are set lower than the usage-% gauges (yellow 70%, red 90%) since even small nonzero PSI values indicate real contention, unlike raw usage.