### PR TITLE
Fix loki HelmRelease: PVC size bump broke the reconcile

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -40,9 +40,9 @@ deploy step; there's no `helm upgrade` to run by hand any more.
 `loki/values.yaml` is kept as a standalone reference copy of the same
 values, not wired in.
 
-Add Loki datasource to Grafana:
-- URL: `http://loki-gateway.observability.svc.cluster.local`
-- Configuration → Data Sources → Add Loki
+The Loki datasource in Grafana is also declarative - see
+`kube-prometheus-stack/helmrelease.yaml`'s `grafana.additionalDataSources`
+- no manual "Add Loki" step needed.
 
 ## Accessing Grafana
 

--- a/infrastructure/kubernetes/observability/loki/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/loki/helmrelease.yaml
@@ -45,10 +45,7 @@ spec:
       # No retention was ever configured before this cutover - logs had
       # been accumulating since the 2026-02-08 install (~117GiB and
       # growing, already past the PVC's nominal 50Gi since nfs-provisioner
-      # doesn't enforce that as a real quota). 180 days at the observed
-      # ~0.6GiB/day growth rate settles around ~108GiB steady-state -
-      # see singleBinary.persistence.size below, bumped to stay honest
-      # about that.
+      # doesn't enforce that as a real quota).
       limits_config:
         retention_period: 4320h
       compactor:
@@ -61,7 +58,16 @@ spec:
       persistence:
         enabled: true
         storageClass: nfs-provisioner
-        size: 150Gi
+        # Left at 50Gi, matching the live PVC, even though actual usage
+        # is already ~117GiB - a StatefulSet's volumeClaimTemplates size
+        # is immutable in place (Kubernetes rejects any change to it
+        # server-side, confirmed live: changing this to 150Gi here failed
+        # the whole HelmRelease reconcile with "Forbidden: updates to
+        # statefulset spec ... other than ... are forbidden"). Fixing the
+        # PVC's declared size for real means a deliberate, disruptive
+        # StatefulSet delete+recreate - not something to fold into a
+        # routine values change.
+        size: 50Gi
         # Chart defaults both to Delete - under Flux's prune:true, a bad
         # merge that drops this manifest from the kustomization would
         # delete the StatefulSet and, with the chart default, the PVC and

--- a/infrastructure/kubernetes/observability/loki/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/loki/helmrelease.yaml
@@ -42,10 +42,6 @@ spec:
               period: 24h
       storage:
         type: filesystem
-      # No retention was ever configured before this cutover - logs had
-      # been accumulating since the 2026-02-08 install (~117GiB and
-      # growing, already past the PVC's nominal 50Gi since nfs-provisioner
-      # doesn't enforce that as a real quota).
       limits_config:
         retention_period: 4320h
       compactor:
@@ -58,15 +54,6 @@ spec:
       persistence:
         enabled: true
         storageClass: nfs-provisioner
-        # Left at 50Gi, matching the live PVC, even though actual usage
-        # is already ~117GiB - a StatefulSet's volumeClaimTemplates size
-        # is immutable in place (Kubernetes rejects any change to it
-        # server-side, confirmed live: changing this to 150Gi here failed
-        # the whole HelmRelease reconcile with "Forbidden: updates to
-        # statefulset spec ... other than ... are forbidden"). Fixing the
-        # PVC's declared size for real means a deliberate, disruptive
-        # StatefulSet delete+recreate - not something to fold into a
-        # routine values change.
         size: 50Gi
         # Chart defaults both to Delete - under Flux's prune:true, a bad
         # merge that drops this manifest from the kustomization would

--- a/infrastructure/kubernetes/observability/loki/values.yaml
+++ b/infrastructure/kubernetes/observability/loki/values.yaml
@@ -16,9 +16,7 @@ loki:
   storage:
     type: filesystem
   # No retention was ever configured before this cutover - logs had been
-  # accumulating since the 2026-02-08 install. 180 days at the observed
-  # ~0.6GiB/day growth rate settles around ~108GiB steady-state - see
-  # singleBinary.persistence.size below, bumped to stay honest about that.
+  # accumulating since the 2026-02-08 install.
   limits_config:
     retention_period: 4320h
   compactor:
@@ -31,7 +29,16 @@ singleBinary:
   persistence:
     enabled: true
     storageClass: nfs-provisioner
-    size: 150Gi
+    # Left at 50Gi, matching the live PVC, even though actual usage is
+    # already ~117GiB - a StatefulSet's volumeClaimTemplates size is
+    # immutable in place (Kubernetes rejects any change to it
+    # server-side, confirmed live: changing this to 150Gi failed the
+    # whole HelmRelease reconcile with "Forbidden: updates to
+    # statefulset spec ... other than ... are forbidden"). Fixing the
+    # PVC's declared size for real means a deliberate, disruptive
+    # StatefulSet delete+recreate - not something to fold into a
+    # routine values change.
+    size: 50Gi
     # Chart defaults both to Delete - under Flux's prune:true, a bad merge
     # that drops this manifest from the kustomization would delete the
     # StatefulSet and, with the chart default, the PVC and all log history

--- a/infrastructure/kubernetes/observability/loki/values.yaml
+++ b/infrastructure/kubernetes/observability/loki/values.yaml
@@ -15,8 +15,6 @@ loki:
           period: 24h
   storage:
     type: filesystem
-  # No retention was ever configured before this cutover - logs had been
-  # accumulating since the 2026-02-08 install.
   limits_config:
     retention_period: 4320h
   compactor:
@@ -29,15 +27,6 @@ singleBinary:
   persistence:
     enabled: true
     storageClass: nfs-provisioner
-    # Left at 50Gi, matching the live PVC, even though actual usage is
-    # already ~117GiB - a StatefulSet's volumeClaimTemplates size is
-    # immutable in place (Kubernetes rejects any change to it
-    # server-side, confirmed live: changing this to 150Gi failed the
-    # whole HelmRelease reconcile with "Forbidden: updates to
-    # statefulset spec ... other than ... are forbidden"). Fixing the
-    # PVC's declared size for real means a deliberate, disruptive
-    # StatefulSet delete+recreate - not something to fold into a
-    # routine values change.
     size: 50Gi
     # Chart defaults both to Delete - under Flux's prune:true, a bad merge
     # that drops this manifest from the kustomization would delete the


### PR DESCRIPTION
**This is a live incident fix.** PR #59 (merged) included a PVC size bump
(50Gi -> 150Gi) alongside the retention/compactor changes. That failed
the actual Flux reconcile:

```
Helm upgrade failed for release observability/loki: server-side apply
failed for StatefulSet: Forbidden: updates to statefulset spec for
fields other than 'replicas', 'ordinals', 'template', 'updateStrategy',
'revisionHistoryLimit', 'persistentVolumeClaimRetentionPolicy' and
'minReadySeconds' are forbidden
```

`volumeClaimTemplates` (the PVC size) isn't in that mutable-field list -
Kubernetes doesn't support resizing a StatefulSet's PVC template in
place, period. My pre-merge `helm upgrade --dry-run=server` test didn't
catch this (doesn't exercise the same server-side-apply path Flux's
helm-controller actually uses).

**Live impact - contained, not an outage:** the whole apply was rejected
atomically, so nothing partially changed. `loki-0` stayed `2/2 Running`,
0 restarts, PVC stayed `Bound` at its original 50Gi the whole time -
reads/writes were unaffected. The casualty: the retention/compactor
config and the `Retain` policy never actually took effect either, since
they were bundled in the same rejected patch as the forbidden size
change.

## Fix

Revert `singleBinary.persistence.size` back to `50Gi` (matching live).
Keep everything else from #59 - 180-day retention, compactor enabled,
`whenDeleted`/`whenScaled: Retain`. The PVC's declared size staying
stale (~117GiB actual vs. 50Gi declared, since `nfs-provisioner` doesn't
enforce it as a real quota) isn't fixed here - actually fixing it means
a deliberate, disruptive StatefulSet delete+recreate, not a routine
values change.

## Verified this time against the actual failing mechanism

Not just `helm --dry-run=server` again (it missed this once already).
Rendered the real StatefulSet via `helm template` with the fixed values,
confirmed `storage: "50Gi"` (unchanged) and
`persistentVolumeClaimRetentionPolicy: Retain` (an allowed mutable
field) in the output, then validated with
`kubectl apply --server-side --force-conflicts --dry-run=server` -
Flux's actual apply mechanism - which now succeeds
(`serverside-applied (server dry run)`, no `Forbidden` error).

## Also includes

The stale-README fix from #64 (closed, folded in here) - the "Add Loki
datasource to Grafana" manual step doesn't apply any more, it's already
declared via `kube-prometheus-stack/helmrelease.yaml`'s
`grafana.additionalDataSources`.