### PR TITLE
Fix stale README instruction - Loki datasource is already declarative

### DIFF
--- a/infrastructure/kubernetes/observability/README.md
+++ b/infrastructure/kubernetes/observability/README.md
@@ -40,9 +40,9 @@ deploy step; there's no `helm upgrade` to run by hand any more.
 `loki/values.yaml` is kept as a standalone reference copy of the same
 values, not wired in.
 
-Add Loki datasource to Grafana:
-- URL: `http://loki-gateway.observability.svc.cluster.local`
-- Configuration → Data Sources → Add Loki
+The Loki datasource in Grafana is also declarative - see
+`kube-prometheus-stack/helmrelease.yaml`'s `grafana.additionalDataSources`
+- no manual "Add Loki" step needed.
 
 ## Accessing Grafana
 


### PR DESCRIPTION
Small doc-only fix, split out from #59's original branch (that commit
didn't make it into #59 before it was merged).

The README's "Add Loki datasource to Grafana" manual step is stale -
it's already declared via \`kube-prometheus-stack/helmrelease.yaml\`'s
\`grafana.additionalDataSources\` (shipped in the original observability
cutover), and verified matching the live Grafana API. No manual step
needed any more.