### PR TITLE
Track Pangolin VPS stack versions via Renovate

### DIFF
--- a/infrastructure/tunnel/README.md
+++ b/infrastructure/tunnel/README.md
@@ -65,3 +65,22 @@ kubectl logs -n tunnel -l app=newt
 ```
 
 Site should show "Online" in Pangolin dashboard.
+
+## Version tracking
+
+Pangolin/Gerbil/Traefik/Badger on the VPS aren't Flux-managed, so nothing
+auto-upgrades them. `docker-compose.yml` and `badger-plugin-version.yml`
+in this directory are mirrors of the real files on the VPS, kept only so
+Renovate scans them and surfaces version drift (PRs / Dependency
+Dashboard entries) - they are never applied by CI. When Renovate flags a
+bump here:
+
+1. SSH to the VPS (`root@<floating IP from opentofu output>`) and check
+   `docker ps` for the versions actually running - the mirrors can lag if
+   a manual upgrade wasn't reflected back here.
+2. Upgrade for real via `docker compose down/pull/up -d` in `/root`,
+   backing up `/root/config` first. Prefer incremental hops over large
+   version jumps; check upstream release notes for breaking changes and
+   required Badger/Newt versions first.
+3. Update the versions in `docker-compose.yml` / `badger-plugin-version.yml`
+   here to match, and merge the Renovate PR (or close it) accordingly.

--- a/infrastructure/tunnel/badger-plugin-version.yml
+++ b/infrastructure/tunnel/badger-plugin-version.yml
@@ -1,0 +1,12 @@
+# Tracking stub for the Traefik Badger plugin version configured in
+# config/traefik/traefik_config.yml on the edge-proxy VPS (see
+# docker-compose.yml in this directory for why this file exists).
+# Pangolin's own migrations bump the real file automatically when you
+# upgrade pangolin past a version that requires a newer Badger - keep
+# this in sync with whatever ends up deployed so Renovate can flag when
+# a newer Badger release exists independently of a pangolin bump.
+experimental:
+  plugins:
+    badger:
+      moduleName: github.com/fosrl/badger
+      version: v1.5.0

--- a/infrastructure/tunnel/docker-compose.yml
+++ b/infrastructure/tunnel/docker-compose.yml
@@ -1,0 +1,64 @@
+# Mirror of /root/docker-compose.yml on the edge-proxy VPS. Not deployed
+# from here - Pangolin runs outside Kubernetes/Flux and is upgraded
+# manually via SSH (see README.md). This copy exists so Renovate's
+# docker-compose manager scans it and flags version drift on the
+# Dependency Dashboard; bump the versions here to match what actually
+# gets deployed after a manual upgrade.
+name: pangolin
+services:
+  pangolin:
+    image: docker.io/fosrl/pangolin:1.21.1
+    container_name: pangolin
+    restart: unless-stopped
+    volumes:
+      - ./config:/app/config
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3001/api/v1/"]
+      interval: "10s"
+      timeout: "10s"
+      retries: 15
+
+  gerbil:
+    image: docker.io/fosrl/gerbil:1.5.0
+    container_name: gerbil
+    restart: unless-stopped
+    depends_on:
+      pangolin:
+        condition: service_healthy
+    command:
+      - --reachableAt=http://gerbil:3004
+      - --generateAndSaveKeyTo=/var/config/key
+      - --remoteConfig=http://pangolin:3001/api/v1/
+    volumes:
+      - ./config/:/var/config
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    ports:
+      - 51820:51820/udp
+      - 21820:21820/udp
+      - 443:443
+      - 80:80
+
+  traefik:
+    image: docker.io/traefik:v3.6
+    container_name: traefik
+    restart: unless-stopped
+
+    network_mode: service:gerbil # Ports appear on the gerbil service
+
+    depends_on:
+      pangolin:
+        condition: service_healthy
+    command:
+      - --configFile=/etc/traefik/traefik_config.yml
+    volumes:
+      - ./config/traefik:/etc/traefik:ro # Volume to store the Traefik configuration
+      - ./config/letsencrypt:/letsencrypt # Volume to store the Let's Encrypt certificates
+      - ./config/traefik/logs:/var/log/traefik # Volume to store Traefik logs
+
+networks:
+  default:
+    driver: bridge
+    name: pangolin
+    enable_ipv6: true

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,17 @@
       "/^infrastructure/kubernetes/.+\\.ya?ml$/"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "infrastructure/tunnel/README.md - Pangolin's edge-proxy VPS stack runs outside Kubernetes/Flux, so track the Traefik Badger plugin version via this stub instead of the kubernetes/flux managers",
+      "managerFilePatterns": ["/^infrastructure/tunnel/badger-plugin-version\\.ya?ml$/"],
+      "matchStrings": ["moduleName:\\s*github\\.com/fosrl/badger\\s*\\n\\s*version:\\s*(?<currentValue>v?[\\d.]+)"],
+      "depNameTemplate": "fosrl/badger",
+      "packageNameTemplate": "fosrl/badger",
+      "datasourceTemplate": "github-releases"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group the *arr media stack together so a bump lands as one PR instead of one per app",


### PR DESCRIPTION
Pangolin/Gerbil/Traefik/Badger run self-hosted on the edge-proxy Hetzner
VPS, outside Kubernetes/Flux, so nothing currently flags when they fall
behind upstream.

This adds a Renovate-only mirror in `infrastructure/tunnel/`:

- `docker-compose.yml` - mirrors the real `/root/docker-compose.yml` on
  the VPS so Renovate's default docker-compose manager picks up
  pangolin/gerbil/traefik image versions.
- `badger-plugin-version.yml` - a small stub tracked via a new
  `customManagers` regex entry in `renovate.json`, since the Traefik
  Badger plugin version lives in a custom `experimental.plugins.badger`
  block Renovate doesn't natively understand.

Neither file is deployed by anything - they exist purely so version
drift shows up as PRs / Dependency Dashboard entries. `README.md` now
documents the loop: when Renovate flags a bump, SSH to the VPS, upgrade
manually (backup config, incremental hops, check breaking changes -
same process used for the 1.15.2 -> 1.21.1 upgrade today), then update
these mirror files to match.