### PR TITLE
Cut most of downloads-standard over to Flux (#15)

### DIFF
--- a/services/downloads-standard/bazarr/deployment.yaml
+++ b/services/downloads-standard/bazarr/deployment.yaml
@@ -119,7 +119,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -6,3 +6,47 @@ resources:
   - namespace.yaml
   - seerr/helmrepository.yaml
   - seerr/helmrelease.yaml
+  - prowlarr/deployment.yaml
+  - prowlarr/ingress.yaml
+  - prowlarr/pvc.yaml
+  - prowlarr/service.yaml
+  - radarr/deployment.yaml
+  - radarr/ingress.yaml
+  - radarr/postgres-databases.yaml
+  - radarr/pvc-config.yaml
+  - radarr/pvc-media.yaml
+  - radarr/service.yaml
+  - radarr-portuguese/deployment.yaml
+  - radarr-portuguese/ingress.yaml
+  - radarr-portuguese/postgres-databases.yaml
+  - radarr-portuguese/pvc-config.yaml
+  - radarr-portuguese/service.yaml
+  - sonarr/deployment.yaml
+  - sonarr/ingress.yaml
+  - sonarr/postgres-databases.yaml
+  - sonarr/pvc-config.yaml
+  - sonarr/service.yaml
+  - sonarr-anime/deployment.yaml
+  - sonarr-anime/ingress.yaml
+  - sonarr-anime/postgres-databases.yaml
+  - sonarr-anime/pvc-config.yaml
+  - sonarr-anime/service.yaml
+  - sonarr-portuguese/deployment.yaml
+  - sonarr-portuguese/ingress.yaml
+  - sonarr-portuguese/postgres-databases.yaml
+  - sonarr-portuguese/pvc-config.yaml
+  - sonarr-portuguese/service.yaml
+  - bazarr/deployment.yaml
+  - bazarr/ingress.yaml
+  - bazarr/postgres-databases.yaml
+  - bazarr/pvc-config.yaml
+  - bazarr/service.yaml
+  - sabnzbd/deployment.yaml
+  - sabnzbd/ingress.yaml
+  - sabnzbd/pvc-config.yaml
+  - sabnzbd/service.yaml
+  - recyclarr/configmap.yaml
+  - recyclarr/cronjob.yaml
+  - upgrade-search/configmap.yaml
+  - upgrade-search/cronjob.yaml
+  - upgrade-search/pvc.yaml

--- a/services/downloads-standard/radarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/radarr-portuguese/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/sabnzbd/deployment.yaml
+++ b/services/downloads-standard/sabnzbd/deployment.yaml
@@ -42,7 +42,7 @@ spec:
             cpu: "200m"
           limits:
             memory: "2Gi"
-            cpu: "2000m"
+            cpu: "2"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/sonarr-anime/deployment.yaml
+++ b/services/downloads-standard/sonarr-anime/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/sonarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/sonarr-portuguese/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:

--- a/services/downloads-standard/sonarr/deployment.yaml
+++ b/services/downloads-standard/sonarr/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             cpu: "100m"
           limits:
             memory: "1Gi"
-            cpu: "1000m"
+            cpu: "1"
       volumes:
       - name: config
         persistentVolumeClaim:


### PR DESCRIPTION
Stacked on #67 (needs it merged first - this branches off it since it
depends on the kustomization.yaml it introduces).

Second `downloads-standard` PR: prowlarr, radarr, radarr-portuguese,
sonarr, sonarr-anime, sonarr-portuguese, bazarr, sabnzbd, recyclarr,
upgrade-search. `qbittorrent-vpn` stays manual for a third PR - the
riskiest piece of this namespace (live VPN sidecar, active torrents).

`radarr/postgres-secret.yaml` and `bazarr/bazarr-secret.yaml` stay
excluded from the kustomization, same reasoning as the Secret exclusions
elsewhere in this rollout.

**Two real findings, both fixed here:**
- CPU limits written as `1000m`/`2000m` in git normalize to `1`/`2` once
  live - byte-different, same quantity. Since these Deployments use
  `strategy: Recreate`, applying the `N000m` form as-is would cause a
  real (if brief) pod recreate on 6 services for a purely cosmetic
  reason. Normalized git to match live's stored form instead.
- `radarr-standard`'s live Deployment was running `RollingUpdate`
  instead of `Recreate` - every sibling app already matched git's
  `Recreate`, radarr-standard alone had drifted. The file already
  documents why: the NFS-backed config PVC isn't RWO-exclusive, so two
  pods writing to it at once (which `RollingUpdate`'s surge allows) can
  corrupt state. This PR's merge fixes that by applying git's existing
  `Recreate` value - a real, one-time pod recreate, not a no-op, but
  restores the documented-safe behavior.

**Verified pre-merge:**
- `kubectl apply --dry-run=server -k services/downloads-standard/` -
  clean.
- `kubectl diff -k services/downloads-standard/` - only 3 real diffs:
  the intentional `radarr-standard` strategy fix, plus the two new
  `seerr` resources from #67 (not yet in `main`, so they show as new
  here too). Everything else is a byte-for-byte no-op.
- Confirmed the 7 apps' `pvc-media.yaml` files are identical copies of
  one shared PVC (`media-standard`) - listed once in the kustomization,
  not per-app, to avoid a duplicate-resource-ID error.
- Confirmed `radarr-main`/`radarr-log`-style `Database` CRs (cross-namespace,
  declared in `downloads-standard/` but targeting `database`) aren't
  already covered by the `database` category's kustomization - no
  double-ownership risk.

Once this and #67 both merge, only `qbittorrent-vpn` is left manual in
this namespace.