### PR TITLE
Fix radarr-standard's rollingUpdate strategy field

### DIFF
--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -10,6 +10,11 @@ spec:
   # concurrent writers from two nodes can corrupt state on this PVC.
   strategy:
     type: Recreate
+    # Explicit null, not omitted: if rollingUpdate is ever set live (even
+    # by something outside this file), Kubernetes rejects any apply that
+    # sets type: Recreate without also clearing it - omitting the key
+    # here wouldn't clear an existing value, only setting it null does.
+    rollingUpdate: null
   selector:
     matchLabels:
       app: radarr-standard

--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -10,10 +10,6 @@ spec:
   # concurrent writers from two nodes can corrupt state on this PVC.
   strategy:
     type: Recreate
-    # Explicit null, not omitted: if rollingUpdate is ever set live (even
-    # by something outside this file), Kubernetes rejects any apply that
-    # sets type: Recreate without also clearing it - omitting the key
-    # here wouldn't clear an existing value, only setting it null does.
     rollingUpdate: null
   selector:
     matchLabels:


### PR DESCRIPTION
`radarr-standard`'s Deployment spec sets `strategy.type: Recreate` but
never cleared `rollingUpdate`. Live still carried that field from before
the strategy fix landed (#69); a manifest that sets `type` without also
nulling `rollingUpdate` leaves it in place, and Kubernetes rejects the
combination outright:

> spec.strategy.rollingUpdate: Forbidden: may not be specified when
> strategy `type` is 'Recreate'

That blocked every reconcile of the `downloads-standard` Kustomization
after #69 merged (contained - the failed apply is atomic, so nothing
partially changed; every pod stayed healthy throughout). Unblocked live
via a one-time `kubectl patch` clearing the field; this PR makes that
fix durable so a future clean re-apply (e.g. disaster recovery) doesn't
hit the same rejection.

**Also worth noting for the record**, unrelated to this specific bug:
that same reconcile (once unblocked) triggered Flux's first-ever
server-side apply takeover of these Deployments, which surfaced two
pods (`prowlarr-standard`, `sonarr-standard`) carrying a stray
`kubectl.kubernetes.io/restartedAt` annotation from an old manual
`kubectl rollout restart`, never in git. Removing it (matching git)
changed their pod-template hash, causing one real (if brief, ~1min)
recreate each - unrelated to this PR's fix, latent drift any first Flux
apply of these Deployments was always going to surface. Both recovered
clean, `1/1 Running`, 0 restarts since.

Verified: `kubectl diff -k services/downloads-standard/` is empty
(byte-for-byte match with live); `kubectl apply --dry-run=server -k`
clean, no validation errors.