### PR TITLE
Cut qbittorrent-vpn over to Flux, completing downloads-standard (#15)

### DIFF
--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -50,3 +50,7 @@ resources:
   - upgrade-search/configmap.yaml
   - upgrade-search/cronjob.yaml
   - upgrade-search/pvc.yaml
+  - qbittorrent-vpn/deployment.yaml
+  - qbittorrent-vpn/ingress.yaml
+  - qbittorrent-vpn/pvc-config.yaml
+  - qbittorrent-vpn/service.yaml


### PR DESCRIPTION
Last piece of `downloads-standard` - the namespace's Flux cutover is now complete (PRs #67, #69, this one). Deliberately saved for last: this is the riskiest manifest in the namespace, a live VPN sidecar (gluetun) with active torrents and a MAM dynamic-seedbox auth sidecar.

## What changed
Adds `qbittorrent-vpn/{deployment,ingress,pvc-config,service}.yaml` to `downloads-standard`'s kustomization. `mam-dynamic-seedbox-secret.yaml` is excluded, same as the other manually-managed Secrets already excluded in this namespace (`radarr/postgres-secret.yaml`, `bazarr/bazarr-secret.yaml`) - it's a Secret with a real value applied out-of-band, not something to hand to Flux's prune. `gluetun-airvpn-wireguard` isn't a git-tracked file at all, so no exclusion needed there.

## Verified before opening
- `kubectl diff -f` on each of the four resources: no drift, byte-identical to live.
- `kubectl diff -k services/downloads-standard/`: clean across the whole namespace.
- Per the `rollingUpdate` incident from #69/#72, also ran the deeper check: `kubectl apply --server-side --force-conflicts --dry-run=server` on each resource individually (not just the namespace-wide classic diff, which is what missed that incident). All four server-side-applied clean, no `Forbidden` cross-field rejections.
- Live pod healthy pre-merge: `3/3 Running`, 0 restarts, 5d3h old; MAM sidecar last successfully re-registered minutes before this check.

Expect a true no-op on merge - Flux adopting an already-identical Deployment/Ingress/Service/PVC, no rollout triggered.