### PR TITLE
Add kube-state-metrics custom resource state for Flux readiness

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -185,17 +185,25 @@ spec:
     kubeStateMetrics:
       enabled: true
 
-    # Flux doesn't expose a Ready/Reconciling/Failed metric itself (that was
-    # dropped in favor of this kube-state-metrics mechanism - see the
-    # flux-cluster dashboard's own description for the panels that had to be
-    # cut without it). This adds gotk_resource_info readiness metrics
-    # *alongside* kube-state-metrics' normal kube_pod_*/kube_deployment_*
-    # output, scoped to the Flux kinds already tracked on that dashboard
-    # (Kustomization/HelmRelease reconcilers, GitRepository/HelmRepository/
-    # Bucket/OCIRepository sources) - deliberately not the full set from
-    # fluxcd/flux2-monitoring-example, and deliberately not passing that
-    # example's --custom-resource-state-only, which would silence the
-    # existing kubernetes-overview/proxmox-overview dashboards.
+    # Flux no longer exposes a Ready/Reconciling/Failed metric itself. See
+    # the flux-cluster dashboard's own description for the panels that got
+    # dropped for lack of it. kube-state-metrics is the replacement: it
+    # reads status.conditions off the CRDs directly.
+    #
+    # This adds gotk_resource_info readiness metrics on top of
+    # kube-state-metrics' normal kube_pod_*/kube_deployment_* output. It
+    # doesn't replace that output.
+    #
+    # Scoped to the kinds already tracked on the flux-cluster dashboard:
+    # Kustomization/HelmRelease reconcilers, and
+    # GitRepository/HelmRepository/Bucket/OCIRepository sources. This is
+    # deliberately a subset of the full config in
+    # fluxcd/flux2-monitoring-example.
+    #
+    # Also deliberately skips that example's --custom-resource-state-only
+    # flag. It would silence the kube_pod_*/kube_deployment_* metrics that
+    # the existing kubernetes-overview and proxmox-overview dashboards
+    # depend on.
     kube-state-metrics:
       rbac:
         extraRules:

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -184,3 +184,149 @@ spec:
 
     kubeStateMetrics:
       enabled: true
+
+    # Flux doesn't expose a Ready/Reconciling/Failed metric itself (that was
+    # dropped in favor of this kube-state-metrics mechanism - see the
+    # flux-cluster dashboard's own description for the panels that had to be
+    # cut without it). This adds gotk_resource_info readiness metrics
+    # *alongside* kube-state-metrics' normal kube_pod_*/kube_deployment_*
+    # output, scoped to the Flux kinds already tracked on that dashboard
+    # (Kustomization/HelmRelease reconcilers, GitRepository/HelmRepository/
+    # Bucket/OCIRepository sources) - deliberately not the full set from
+    # fluxcd/flux2-monitoring-example, and deliberately not passing that
+    # example's --custom-resource-state-only, which would silence the
+    # existing kubernetes-overview/proxmox-overview dashboards.
+    kube-state-metrics:
+      rbac:
+        extraRules:
+          - apiGroups:
+              - source.toolkit.fluxcd.io
+              - kustomize.toolkit.fluxcd.io
+              - helm.toolkit.fluxcd.io
+            resources:
+              - gitrepositories
+              - helmrepositories
+              - buckets
+              - ocirepositories
+              - kustomizations
+              - helmreleases
+            verbs: ["list", "watch"]
+      customResourceState:
+        enabled: true
+        config:
+          spec:
+            resources:
+              - groupVersionKind:
+                  group: kustomize.toolkit.fluxcd.io
+                  version: v1
+                  kind: Kustomization
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux Kustomization resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, lastAppliedRevision]
+                      source_name: [spec, sourceRef, name]
+              - groupVersionKind:
+                  group: helm.toolkit.fluxcd.io
+                  version: v2
+                  kind: HelmRelease
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux HelmRelease resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, history, "0", chartVersion]
+                      chart_name: [status, history, "0", chartName]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: GitRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux GitRepository resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, artifact, revision]
+                      url: [spec, url]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: HelmRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux HelmRepository resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, artifact, revision]
+                      url: [spec, url]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: Bucket
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux Bucket resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, artifact, revision]
+                      bucket_name: [spec, bucketName]
+              - groupVersionKind:
+                  group: source.toolkit.fluxcd.io
+                  version: v1
+                  kind: OCIRepository
+                metricNamePrefix: gotk
+                metrics:
+                  - name: "resource_info"
+                    help: "The current state of a Flux OCIRepository resource."
+                    each:
+                      type: Info
+                      info:
+                        labelsFromPath:
+                          name: [metadata, name]
+                    labelsFromPath:
+                      exported_namespace: [metadata, namespace]
+                      ready: [status, conditions, "[type=Ready]", status]
+                      suspended: [spec, suspend]
+                      revision: [status, artifact, revision]
+                      url: [spec, url]


### PR DESCRIPTION
## What

Configures kube-state-metrics to publish a readiness metric (`gotk_resource_info`) for Flux's Kustomizations, HelmReleases, GitRepositories, HelmRepositories, Buckets, and OCIRepositories.

## Why

Flux used to publish its own Ready/Reconciling/Failed metric, but that's gone in the version we're running. All Prometheus has today is reconciliation timing, not status. The flux-cluster dashboard already dropped its readiness panels for exactly this reason.

The replacement mechanism is kube-state-metrics reading each resource's `status.conditions` directly. Nothing here was configured to do that, so this PR wires it up.

This is groundwork, not the final feature. Once this is deployed and confirmed working, the plan is to build a status-timeline panel on the flux-cluster dashboard, sorted by progress.

## Scope decisions

Only the kinds already tracked on the flux-cluster dashboard are covered here. The upstream reference config (`fluxcd/flux2-monitoring-example`) also covers notification and image toolkit CRDs, which we don't use for this.

We're also deliberately skipping that reference config's `--custom-resource-state-only` flag. It would silence kube-state-metrics' normal `kube_pod_*`/`kube_deployment_*` output, which the existing kubernetes-overview and proxmox-overview dashboards depend on.

## Testing

Not yet deployed. Plan is to merge, let Flux reconcile, then confirm `gotk_resource_info` shows up in Prometheus before building anything on top of it.
