### PR TITLE
Add Headlamp for live Flux reconciliation view

### DIFF
--- a/infrastructure/kubernetes/observability/headlamp/flux-rbac.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/flux-rbac.yaml
@@ -1,0 +1,34 @@
+# The chart's own clusterRoleBinding (helmrelease.yaml) binds the headlamp
+# ServiceAccount to the built-in `view` ClusterRole - broad read access to
+# most resources, but excludes Secrets and doesn't cover Flux's CRDs (view's
+# aggregation labels predate Flux and were never extended to its API
+# groups). This ClusterRole/Binding adds read access to those four groups
+# on top, so Headlamp (and its Flux plugin) can see Kustomizations,
+# HelmReleases, sources, and Alerts/Providers without granting anything
+# broader - RBAC bindings union, so this simply adds to what `view` already
+# grants rather than replacing it.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: headlamp-flux-view
+rules:
+  - apiGroups:
+      - kustomize.toolkit.fluxcd.io
+      - helm.toolkit.fluxcd.io
+      - source.toolkit.fluxcd.io
+      - notification.toolkit.fluxcd.io
+    resources: ["*"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: headlamp-flux-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: headlamp-flux-view
+subjects:
+  - kind: ServiceAccount
+    name: headlamp
+    namespace: observability

--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -1,0 +1,86 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: headlamp
+  namespace: observability
+spec:
+  interval: 30m
+  timeout: 15m
+  releaseName: headlamp
+  chart:
+    spec:
+      chart: headlamp
+      version: "0.45.0"
+      sourceRef:
+        kind: HelmRepository
+        name: headlamp
+  install:
+    remediation:
+      retries: 1
+  upgrade:
+    remediation:
+      retries: 1
+  values:
+    serviceAccount:
+      # Named explicitly (chart default is fullname-generated) so
+      # flux-rbac.yaml's ClusterRoleBinding subject can reference it without
+      # guessing the generated name.
+      name: headlamp
+
+    clusterRoleBinding:
+      # Chart default is cluster-admin. `view` (built-in, read-only,
+      # excludes Secrets) plus flux-rbac.yaml's extra read access to Flux's
+      # own CRDs covers everything the UI and its Flux plugin need.
+      clusterRoleName: view
+
+    config:
+      # Tailnet-only exposure (no OIDC provider set up anywhere in this
+      # cluster) - let the pod authenticate as its own ServiceAccount
+      # instead of prompting for a token. Safe here specifically because
+      # that ServiceAccount is scoped to view/flux-view above, not
+      # cluster-admin.
+      unsafeUseServiceAccountToken: true
+
+    initContainers:
+      - name: install-flux-plugin
+        image: ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.7.0
+        command:
+          - sh
+          - -c
+          # chown to 100:101: the main container runs as that non-root
+          # user/group and can't read root-owned files otherwise.
+          - cp -r /plugins/* /headlamp/plugins/ && chown -R 100:101 /headlamp/plugins
+        volumeMounts:
+          - name: plugins
+            mountPath: /headlamp/plugins
+
+    volumes:
+      - name: plugins
+        emptyDir: {}
+
+    volumeMounts:
+      - name: plugins
+        mountPath: /headlamp/plugins
+
+    ingress:
+      enabled: true
+      ingressClassName: nginx
+      annotations:
+        cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+        nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+      hosts:
+        - host: headlamp.labmatt.com
+          paths:
+            - path: /
+              type: Prefix
+      tls:
+        - hosts:
+            - headlamp.labmatt.com
+          secretName: headlamp-tls
+
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 256Mi

--- a/infrastructure/kubernetes/observability/headlamp/helmrepository.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrepository.yaml
@@ -1,0 +1,8 @@
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: headlamp
+  namespace: observability
+spec:
+  interval: 1h
+  url: https://kubernetes-sigs.github.io/headlamp/

--- a/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
@@ -1,11 +1,10 @@
-# See services/jellyfin/ingress-block-metrics.yaml for the mechanism this
-# relies on: headlamp.labmatt.com sits under the labmatt.com Cloudflare
-# wildcard record like every other host, but only resolves to the
-# in-cluster ingress-nginx LoadBalancer's private IP for tailnet/LAN
-# clients via internal DNS - it's never registered as internet-reachable,
-# so no equivalent Pangolin/Cloudflare-facing route is needed. That
-# internal DNS override lives outside this repo and still needs adding for
-# this host - see #77.
+# headlamp.labmatt.com resolves via the *.labmatt.com Cloudflare wildcard
+# (infrastructure/cloudflare/opentofu/main.tf), which already points at
+# ingress-nginx's internal LoadBalancer IP (10.0.10.2), not a public one -
+# same mechanism jellyfin.labmatt.com uses (see
+# services/jellyfin/ingress-block-metrics.yaml). Only names listed in
+# tunnel_hostnames get an override to Pangolin's public IP instead; this
+# host isn't in that list, so no DNS work is needed here - see #77.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
@@ -1,10 +1,3 @@
-# headlamp.labmatt.com resolves via the *.labmatt.com Cloudflare wildcard
-# (infrastructure/cloudflare/opentofu/main.tf), which already points at
-# ingress-nginx's internal LoadBalancer IP (10.0.10.2), not a public one -
-# same mechanism jellyfin.labmatt.com uses (see
-# services/jellyfin/ingress-block-metrics.yaml). Only names listed in
-# tunnel_hostnames get an override to Pangolin's public IP instead; this
-# host isn't in that list, so no DNS work is needed here - see #77.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:

--- a/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/kustomization.yaml
@@ -1,0 +1,14 @@
+# See services/jellyfin/ingress-block-metrics.yaml for the mechanism this
+# relies on: headlamp.labmatt.com sits under the labmatt.com Cloudflare
+# wildcard record like every other host, but only resolves to the
+# in-cluster ingress-nginx LoadBalancer's private IP for tailnet/LAN
+# clients via internal DNS - it's never registered as internet-reachable,
+# so no equivalent Pangolin/Cloudflare-facing route is needed. That
+# internal DNS override lives outside this repo and still needs adding for
+# this host - see #77.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - helmrepository.yaml
+  - helmrelease.yaml
+  - flux-rbac.yaml

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -32,3 +32,4 @@ resources:
   - ntfy/deployment.yaml
   - ntfy/ingress.yaml
   - services/jellyfin-servicemonitor.yaml
+  - headlamp

--- a/renovate.json
+++ b/renovate.json
@@ -17,6 +17,19 @@
       "/^infrastructure/kubernetes/.+\\.ya?ml$/"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "The kubernetes/flux managers above extract chart versions and top-level manifest images, but not images nested inside arbitrary HelmRelease values (e.g. an initContainer) - this tracks Headlamp's pinned Flux plugin image tag explicitly so it isn't silently missed.",
+      "managerFilePatterns": [
+        "/^infrastructure/kubernetes/observability/headlamp/helmrelease\\.yaml$/"
+      ],
+      "matchStrings": [
+        "image: (?<depName>ghcr\\.io/headlamp-k8s/headlamp-plugin-flux):(?<currentValue>[^\\s]+)"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ],
   "packageRules": [
     {
       "description": "Group the *arr media stack together so a bump lands as one PR instead of one per app",


### PR DESCRIPTION
Closes #77.

Flux-managed HelmRelease (chart 0.45.0) under `infrastructure/kubernetes/observability/headlamp`, with the Flux plugin (`ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.7.0`) staged via an initContainer per the chart's documented plugin pattern.

**RBAC**: scoped to `view` (built-in) plus explicit read access to the four `toolkit.fluxcd.io` API groups (`flux-rbac.yaml`), not the chart's `cluster-admin` default. Still excludes Secrets even though exposure is tailnet-only. Auth uses the pod's own ServiceAccount token (`unsafeUseServiceAccountToken`) since no OIDC provider exists anywhere in this cluster - safe given the scoped RBAC.

**Ingress**: `headlamp.labmatt.com`. Resolves via the existing `*.labmatt.com` Cloudflare wildcard, which already points at ingress-nginx's internal LoadBalancer IP (`10.0.10.2`, not public) - same mechanism `jellyfin.labmatt.com` uses. No new DNS record needed; only the opt-in `tunnel_hostnames` list gets an override to Pangolin's public IP instead, and this host isn't in it.

**Renovate**: added a `customManagers` regex entry for the Flux plugin's image tag - it's nested inside HelmRelease values (an initContainer), which the existing `kubernetes`/`flux` managers don't parse, so it would otherwise go untracked. Chart version bump tracking already works via the existing `flux` manager scope (no changes needed there).

**Considered and rejected**: Weave GitOps (#77's original target) - no commits in months, ~88 open issues. Capacitor - narrower RBAC footprint, but passed over since exposure is tailnet-only, removing most of the reason to prefer it over Headlamp's broader scope and stronger maintenance backing (CNCF sandbox).

**Verified pre-merge**:
- `kubectl kustomize` builds cleanly
- `kubectl apply --dry-run=server -k infrastructure/kubernetes/observability` - all 4 new objects (`HelmRelease`, `HelmRepository`, `ClusterRole`, `ClusterRoleBinding`) create cleanly, no errors elsewhere in the category
- Pulled the actual chart (0.45.0) and ran `helm template` with the real values, then `kubectl apply --server-side --force-conflicts --dry-run=server` on the rendered output - all 6 rendered objects apply cleanly. Confirmed the rendered `ClusterRoleBinding` targets `view` (not the chart's cluster-admin default) and the rendered `ServiceAccount` name (`headlamp`) matches `flux-rbac.yaml`'s binding subject exactly.