### PR TITLE
Fix Headlamp's Flux plugin initContainer crashlooping

### DIFF
--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -47,9 +47,12 @@ spec:
         command:
           - sh
           - -c
-          # chown to 100:101: the main container runs as that non-root
-          # user/group and can't read root-owned files otherwise.
-          - cp -r /plugins/* /headlamp/plugins/ && chown -R 100:101 /headlamp/plugins
+          # No chown needed (unlike the plugin's own doc example): this
+          # image's own default user is already 100:101, matching the
+          # main container - a chown here would actually fail, since a
+          # non-root process can't change file ownership even on files
+          # it already owns.
+          - cp -r /plugins/* /headlamp/plugins/
         volumeMounts:
           - name: plugins
             mountPath: /headlamp/plugins

--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -47,10 +47,11 @@ spec:
         command:
           - sh
           - -c
-          # No chown needed: this image's own default user is already
-          # 100:101, matching the main container. Adding one would
-          # actually fail - a non-root process can't change file
-          # ownership, even on files it already owns.
+          # No chown needed (unlike the plugin's own doc example): this
+          # image's own default user is already 100:101, matching the
+          # main container - a chown here would actually fail, since a
+          # non-root process can't change file ownership even on files
+          # it already owns.
           - cp -r /plugins/* /headlamp/plugins/
         volumeMounts:
           - name: plugins

--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -47,11 +47,10 @@ spec:
         command:
           - sh
           - -c
-          # No chown needed (unlike the plugin's own doc example): this
-          # image's own default user is already 100:101, matching the
-          # main container - a chown here would actually fail, since a
-          # non-root process can't change file ownership even on files
-          # it already owns.
+          # No chown needed: this image's own default user is already
+          # 100:101, matching the main container. Adding one would
+          # actually fail - a non-root process can't change file
+          # ownership, even on files it already owns.
           - cp -r /plugins/* /headlamp/plugins/
         volumeMounts:
           - name: plugins


### PR DESCRIPTION
Follow-up to #78, merged and live with a bug I introduced: the initContainer that stages the Flux plugin was crashlooping (`Init:Error`), leaving the headlamp Deployment with zero ready pods - visible live as a 503 at `headlamp.labmatt.com` (plus a TLS error, since cert-manager's Certificate hadn't finished issuing yet either, though that part looks like ordinary in-progress issuance rather than caused by this).

**Root cause**: `ghcr.io/headlamp-k8s/headlamp-plugin-flux:v0.7.0` already runs as UID 100 / GID 101 by default (confirmed via the pod's actual runtime user, matching the main headlamp container) - so `cp`'s output is already correctly owned. The `chown -R 100:101` I added afterward (copied from the plugin's own doc example, which assumes the initContainer runs as root) is redundant at best and fatal in practice: a non-root process can't `chown`, even files it already owns. Confirmed live:

```
chown: /headlamp/plugins: Operation not permitted
```

**Fix**: drop the `chown` step entirely - the copy alone is sufficient.

No other changes; everything else from #78 (RBAC, ingress, Renovate tracking) is untouched.