### PR TITLE
Tighten headlamp HelmRelease timeout to 5m

### DIFF
--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -5,8 +5,6 @@ metadata:
   namespace: observability
 spec:
   interval: 30m
-  # Flux's own default (unlike jellyfin's 15m, copied from that chart's
-  # heavier pull/startup - too generous for this single small binary).
   timeout: 5m
   releaseName: headlamp
   chart:

--- a/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/helmrelease.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: observability
 spec:
   interval: 30m
-  timeout: 15m
+  # Flux's own default (unlike jellyfin's 15m, copied from that chart's
+  # heavier pull/startup - too generous for this single small binary).
+  timeout: 5m
   releaseName: headlamp
   chart:
     spec:


### PR DESCRIPTION
The timeout: 15m in #78 was copied from jellyfin's helmrelease.yaml without reconsidering it for this workload - jellyfin's value accounts for a heavier image pull and startup, which doesn't apply to a single small Go binary like Headlamp.

Flux's own documented default for spec.timeout is 5m0s (https://fluxcd.io/flux/components/helm/helmreleases/) - using that explicitly rather than an arbitrary pick.

Practical upshot: this is also why the stuck install from #79's chown bug took ~15 minutes to time out and retry instead of ~5.