### PR TITLE
Fix Headlamp Flux plugin reporting 'Flux is not installed'

### DIFF
--- a/infrastructure/kubernetes/observability/headlamp/flux-rbac.yaml
+++ b/infrastructure/kubernetes/observability/headlamp/flux-rbac.yaml
@@ -19,6 +19,16 @@ rules:
       - notification.toolkit.fluxcd.io
     resources: ["*"]
     verbs: ["get", "list", "watch"]
+  # The Flux plugin's own "is Flux installed" check lists CRD objects
+  # (e.g. kustomizations.kustomize.toolkit.fluxcd.io) rather than the
+  # custom resources themselves - without this it reports Flux as not
+  # installed even though the rule above already grants read on the
+  # actual Kustomizations/HelmReleases/sources.
+  - apiGroups:
+      - apiextensions.k8s.io
+    resources:
+      - customresourcedefinitions
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Follow-up to #78. Live after that PR merged, the Flux plugin showed 'Flux is not installed' despite Flux clearly running and Headlamp already able to read Kustomizations/HelmReleases/sources fine.

Root cause: the plugin's own installed-check lists CRD objects (e.g. the kustomizations.kustomize.toolkit.fluxcd.io CRD itself) to detect Flux, not the custom resources those CRDs define. flux-rbac.yaml only granted read on the actual resources (Kustomization, HelmRelease, etc.), not on CustomResourceDefinitions - a gap the earlier server-side dry-run checks couldn't have caught, since dry-run validates the RBAC objects apply cleanly, not whether a specific downstream consumer's runtime check happens to need a permission nobody anticipated.

Confirmed live before this fix: `kubectl auth can-i list customresourcedefinitions --as=system:serviceaccount:observability:headlamp` -> no.

Already applied directly to the live cluster to unblock/verify (pure read-only RBAC addition, no disruption) - this PR is the durable git record so Flux doesn't revert it on next reconcile.