### PR TITLE
Fix pangolin-test smoke test: missing Ingress host and blueprint site ID

### DIFF
--- a/infrastructure/kubernetes/ingress/kustomization.yaml
+++ b/infrastructure/kubernetes/ingress/kustomization.yaml
@@ -1,13 +1,10 @@
 # Flux-managed. See clusters/eye-of-michael/flux-system/ingress.yaml for
 # the Kustomization CR that reconciles this path, and #15 for the rollout
 # plan this cutover is part of.
-#
-# test-ingress.yaml is a manual smoke-test manifest (hello-world app) with
-# no live resources on the cluster right now - deliberately left out so
-# this cutover doesn't deploy it.
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
   - helmrepository.yaml
   - helmrelease.yaml
+  - test-ingress.yaml

--- a/infrastructure/kubernetes/ingress/test-ingress.yaml
+++ b/infrastructure/kubernetes/ingress/test-ingress.yaml
@@ -45,7 +45,8 @@ metadata:
 spec:
   ingressClassName: nginx
   rules:
-    - http:
+    - host: pangolin-test.labmatt.com
+      http:
         paths:
           - path: /
             pathType: Prefix

--- a/infrastructure/tunnel/blueprints/pangolin-test.yaml
+++ b/infrastructure/tunnel/blueprints/pangolin-test.yaml
@@ -1,0 +1,10 @@
+public-resources:
+  pangolin-test:
+    name: "Pangolin Test"
+    mode: http
+    full-domain: pangolin-test.labmatt.com
+    targets:
+      - site: faithful-brachyurophis-fasciolatus
+        method: http
+        hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
+        port: 80

--- a/infrastructure/tunnel/blueprints/pangolin-test.yaml
+++ b/infrastructure/tunnel/blueprints/pangolin-test.yaml
@@ -8,3 +8,28 @@ public-resources:
         method: http
         hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
         port: 80
+    auth:
+      sso-enabled: true
+      sso-roles:
+        - Member
+    rules:
+      - action: deny
+        match: path
+        value: /metrics
+        priority: 1
+      - action: allow
+        match: country
+        value: US
+        priority: 2
+      - action: allow
+        match: country
+        value: DE
+        priority: 3
+      - action: allow
+        match: country
+        value: NL
+        priority: 4
+      - action: allow
+        match: country
+        value: GB
+        priority: 5


### PR DESCRIPTION
## What

- \`hello-world\`'s \`Ingress\` had no \`host\`, so nginx-ingress fell
  through to its default backend (404) for \`pangolin-test.labmatt.com\`
  instead of routing to it. Added \`host: pangolin-test.labmatt.com\`.
- \`test-ingress.yaml\` was excluded entirely from the ingress
  Kustomization. Added it to \`resources:\`.
- The Pangolin blueprint separately referenced a nonexistent site name
  (\`homelab\`) instead of the real registered site ID
  (\`faithful-brachyurophis-fasciolatus\`).

## Why

\`https://pangolin-test.labmatt.com/\` was 404ing during the Pangolin
Blueprints smoke test - this was the cause.