### PR TITLE
Add Renovate minimumReleaseAge with security carve-out

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "dependencyDashboard": true,
   "labels": ["renovate"],
   "prConcurrentLimit": 5,
-  "minimumReleaseAge": "3 days",
+  "minimumReleaseAge": "7 days",
   "vulnerabilityAlerts": {
     "minimumReleaseAge": "0 days"
   },

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "dependencyDashboard": true,
   "labels": ["renovate"],
   "prConcurrentLimit": 5,
+  "minimumReleaseAge": "3 days",
+  "vulnerabilityAlerts": {
+    "minimumReleaseAge": "0 days"
+  },
   "kubernetes": {
     "managerFilePatterns": [
       "/^services/.+\\.ya?ml$/",


### PR DESCRIPTION
## What

Sets Renovate's `minimumReleaseAge` to `7 days` globally, with an
explicit `vulnerabilityAlerts.minimumReleaseAge: "0 days"` carve-out so
security patches aren't held back by the same window.

## Why

Flux now applies changes for most `infrastructure/kubernetes/*` and
`services/*` paths, so merging a Renovate PR is a live deploy, not just
a git change. `minimumReleaseAge` gives a just-shipped release a week
to get caught/pulled upstream (bad release, compromised package, etc.)
before it reaches us, while letting known CVEs through immediately.

This was one of the "Decided" items on #56 (Flux hardening); split out
into its own ticket at #104 since it's independently actionable.

## Research

- Renovate's own docs on [`minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)
  and the dedicated [Minimum Release Age](https://docs.renovatebot.com/key-concepts/minimum-release-age/)
  key-concepts page confirm vulnerability alerts already bypass
  `minimumReleaseAge` by default - the explicit `vulnerabilityAlerts`
  block here just makes that self-documenting in our config rather than
  relying on the default silently.
- Renovate's own [Upgrade best practices](https://docs.renovatebot.com/upgrade-best-practices/)
  page recommends `minimumReleaseAge` for anyone automerging or merging
  quickly, specifically to give time for a bad/malicious release to get
  pulled before it reaches you.
- Community discussion threads
  ([renovatebot/renovate#37952](https://github.com/renovatebot/renovate/discussions/37952),
  [renovatebot/renovate#42269](https://github.com/renovatebot/renovate/discussions/42269))
  converge on the same global-delay + zero-day-security-carve-out
  pattern used here; recommendations range from a few days up to 14
  for stricter supply-chain hardening. 7 days lines up with a weekly
  review cadence and is a reasonable middle ground.

## Testing

Config-only change (`renovate.json`); no cluster-side effect until
Renovate's next scheduled run. Will confirm delayed PRs show up on the
Dependency Dashboard (#3) with the expected reasoning as part of #104's
done criteria.

Closes #104