### PR TITLE
Track Talos OS version with a Renovate custom manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -32,6 +32,18 @@
         "image: (?<depName>ghcr\\.io/headlamp-k8s/headlamp-plugin-flux):(?<currentValue>[^\\s]+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    {
+      "customType": "regex",
+      "description": "Track the fleet's target Talos OS version (locals.talos_version) so a new release shows up as a PR - this only bumps the pinned version string, it does not run talosctl upgrade against live nodes. Deliberately excludes cluster_secrets_talos_version right below it, which must never track this value (see comment in locals.tf).",
+      "managerFilePatterns": [
+        "/^infrastructure/proxmox/opentofu/locals\\.tf$/"
+      ],
+      "matchStrings": [
+        "(?<!cluster_secrets_)talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\""
+      ],
+      "depNameTemplate": "siderolabs/talos",
+      "datasourceTemplate": "github-releases"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## Why

The Talos node OS version (`locals.talos_version` in `infrastructure/proxmox/opentofu/locals.tf`) wasn't tracked by Renovate at all - only the Talos *Terraform provider* version was, which is a different thing. Bumping the actual node OS target required manually noticing a new Talos release.

## What this does

Adds a regex `customManager` watching `talos_version` against `siderolabs/talos` GitHub releases, following the same pattern already used for Headlamp's pinned plugin image.

Deliberately excludes `cluster_secrets_talos_version` (the line right below it) via a negative lookbehind - that value must never change after initial bootstrap (see the existing comment in `locals.tf`: it pins the cluster's PKI/CA generation, and bumping it would desync the CA from the already-running cluster).

## Scope

This only tracks the pinned install-image version used for new/rebuilt nodes and opens a PR when it changes. It does **not** run `talosctl upgrade` against already-running nodes - that stays a separate, manual, per-node step after merging.