### PR TITLE
Fix books-sync 502 on Kobo library sync with generous nginx buffer sizing

### DIFF
--- a/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
+++ b/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
@@ -26,6 +26,9 @@ kind: Ingress
 metadata:
   name: calibre-web-automated-books-sync
   namespace: downloads-standard
+  annotations:
+    # CWA requires >4k to enable sync
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
 spec:
   ingressClassName: nginx
   rules:

--- a/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
+++ b/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
@@ -27,8 +27,17 @@ metadata:
   name: calibre-web-automated-books-sync
   namespace: downloads-standard
   annotations:
-    # CWA requires >4k to enable sync
-    nginx.ingress.kubernetes.io/proxy-buffer-size: "16k"
+    # CWA's /v1/library/sync packs enough into response headers that a
+    # single proxy-buffer-size bump isn't enough - proxy-buffers-number
+    # and proxy-busy-buffers-size need to grow together or nginx's config
+    # validation itself can reject the value. Sized generously rather
+    # than minimally: this route serves one Kobo's occasional syncs, so
+    # buffer memory cost is negligible, while under-sizing means another
+    # full device-retry debug loop. See:
+    # https://github.com/kubernetes/ingress-nginx/issues/363
+    nginx.ingress.kubernetes.io/proxy-buffer-size: "256k"
+    nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
+    nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "256k"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
CWA's `/v1/library/sync` response headers exceed nginx's default 4k buffer, failing as `upstream sent too big header` (502) and showing on the Kobo device as a generic failed sync. This is a known failure mode for Kobo sync behind nginx - see [booklore-app/booklore#1301](https://github.com/booklore-app/booklore/issues/1301) for the same symptom on a different self-hosted Kobo-sync server.

A single `proxy-buffer-size` bump risks nginx config validation failure on its own (`proxy_busy_buffers_size` must stay under `(proxy_buffers count × size) - one buffer` - see [kubernetes/ingress-nginx#363](https://github.com/kubernetes/ingress-nginx/issues/363)), so this sets `proxy-buffer-size`, `proxy-buffers-number`, and `proxy-busy-buffers-size` together (256k/4/256k), verified live to clear the 502 on the real `/v1/library/sync` call.

Sized generously rather than minimally since this route only serves one device's occasional syncs - the memory cost is negligible, and under-sizing means another full physical-device retry loop to diagnose.