### PR TITLE
Rate-limit books-sync's /kobo/ path via nginx-ingress

### DIFF
--- a/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
+++ b/services/downloads-standard/calibre-web-automated/ingress-books-sync.yaml
@@ -10,8 +10,7 @@
 # CWA's Kobo Sync token is embedded directly in the URL
 # (/kobo/<token>/...) and checked per-request by CWA itself - that token
 # is the entire auth for this path by design. See issue #17 for the full
-# reasoning and the required Pangolin dashboard steps (bypass-auth +
-# rate-limit rule scoped to /kobo/) that aren't managed as code here.
+# reasoning.
 #
 # No TLS/cert-manager/force-ssl-redirect here, unlike ingress.yaml
 # (books.labmatt.com): this host is Pangolin-fronted, same pattern as
@@ -38,6 +37,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-buffer-size: "256k"
     nginx.ingress.kubernetes.io/proxy-buffers-number: "4"
     nginx.ingress.kubernetes.io/proxy-busy-buffers-size: "256k"
+    nginx.ingress.kubernetes.io/limit-rps: "5"
+    nginx.ingress.kubernetes.io/limit-burst-multiplier: "3"
 spec:
   ingressClassName: nginx
   rules:


### PR DESCRIPTION
Follow-up to #17/#19.

Issue #17's design called for a Pangolin rate-limit rule on `/kobo/`, but Pangolin's Rules engine has no rate-limit action/match type at all (confirmed against `docs.pangolin.net/manage/access-control/rules` - only `path`/`country`/`region`/`CIDR`/`IP`/`ASN` matches with `Bypass Auth`/`Block Access`/`Pass to Auth` actions). A Traefik-level middleware would need #62 (Pangolin's substrate config isn't in git) done first.

Adds `nginx.ingress.kubernetes.io/limit-rps`/`limit-burst-multiplier` to `ingress-books-sync.yaml` instead - same defense-in-depth intent, entirely as code, no #62 dependency, deploys via the existing Flux-managed `downloads-standard` kustomization.

## Verified
- `kubectl apply --dry-run=client` clean
- `kubectl kustomize` + `kubectl apply --server-side --dry-run=server` clean across the full `downloads-standard` render, no errors