### PR TITLE
Add kube-linter as a required CI check (zero checks enabled yet)

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -122,7 +122,7 @@ jobs:
 
           printf '%s\n' "${files[@]}"
           set +e
-          output=$(kube-linter lint --format plain "${files[@]}" 2>&1)
+          output=$(kube-linter lint --config .kube-linter.yaml --format plain "${files[@]}" 2>&1)
           exit_code=$?
           set -e
 

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -79,3 +79,77 @@ jobs:
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             -ignore-missing-schemas \
             "${files[@]}"
+
+  kube-linter:
+    name: Kubernetes manifest lint (kube-linter, advisory)
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Install kube-linter
+        env:
+          KUBE_LINTER_VERSION: "0.8.3"
+          KUBE_LINTER_SHA256: "1a6d8419b11971372971fdbc22682b684ebfb7cf1c39591662d1b6ca736c41df"
+        run: |
+          set -e
+          curl -sSLO "https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-linux.tar.gz"
+          echo "${KUBE_LINTER_SHA256}  kube-linter-linux.tar.gz" | sha256sum -c -
+          tar xz -f kube-linter-linux.tar.gz kube-linter
+          sudo install kube-linter /usr/local/bin/kube-linter
+
+      - name: kube-linter (changed manifests only)
+        id: lint
+        run: |
+          set -e
+          # Advisory pass 1 (issue #115): scoped to manifests this PR
+          # touches, same as tofu fmt above - repo-wide has ~130 pre-existing
+          # findings today, so a full sweep would drown every PR in noise
+          # unrelated to what it's changing.
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- \
+            'services/*.yaml' 'services/*.yml' 'infrastructure/kubernetes/*.yaml' 'infrastructure/kubernetes/*.yml' \
+            ':(exclude)*values.yaml' ':(exclude)*values.yml')
+
+          echo "files_changed=$([ "${#files[@]}" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Kubernetes manifests changed - skipping"
+            exit 0
+          fi
+
+          printf '%s\n' "${files[@]}"
+          set +e
+          output=$(kube-linter lint --format plain "${files[@]}" 2>&1)
+          exit_code=$?
+          set -e
+
+          echo "$output"
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          {
+            echo "report<<KUBE_LINTER_EOF"
+            echo "$output"
+            echo "KUBE_LINTER_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment findings on PR
+        if: steps.lint.outputs.files_changed == 'true'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: kube-linter
+          message: |
+            ### kube-linter ${{ steps.lint.outputs.exit_code == '0' && '✅ no findings' || '⚠️ findings' }} (advisory, non-blocking)
+
+            Checked against the Kubernetes manifests changed in this PR. This is
+            advisory-only for now (see [#115](../../issues/115)) - it does not
+            block merge.
+
+            <details><summary>kube-linter output</summary>
+
+            ```
+            ${{ steps.lint.outputs.report }}
+            ```
+
+            </details>

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -81,7 +81,7 @@ jobs:
             "${files[@]}"
 
   kube-linter:
-    name: Kubernetes manifest lint (kube-linter, advisory)
+    name: Kubernetes manifest lint (kube-linter)
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -106,10 +106,9 @@ jobs:
         id: lint
         run: |
           set -e
-          # Advisory pass 1 (issue #115): scoped to manifests this PR
-          # touches, same as tofu fmt above - repo-wide has ~130 pre-existing
-          # findings today, so a full sweep would drown every PR in noise
-          # unrelated to what it's changing.
+          # Scoped to manifests this PR touches, same as tofu fmt above -
+          # repo-wide has ~100 pre-existing findings today, so a full sweep
+          # would drown every PR in noise unrelated to what it's changing.
           mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- \
             'services/*.yaml' 'services/*.yml' 'infrastructure/kubernetes/*.yaml' 'infrastructure/kubernetes/*.yml' \
             ':(exclude)*values.yaml' ':(exclude)*values.yml')
@@ -134,17 +133,25 @@ jobs:
             echo "KUBE_LINTER_EOF"
           } >> "$GITHUB_OUTPUT"
 
+          # Required check, not advisory - .kube-linter.yaml starts with zero
+          # checks enabled (doNotAutoAddDefaults: true), so this passes
+          # trivially until checks are opted in one at a time, each paired
+          # with the fixes for whatever it finds. See #115/#116.
+          exit "$exit_code"
+
       - name: Comment findings on PR
-        if: steps.lint.outputs.files_changed == 'true'
+        if: always() && steps.lint.outputs.files_changed == 'true'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: kube-linter
           message: |
-            ### kube-linter ${{ steps.lint.outputs.exit_code == '0' && '✅ no findings' || '⚠️ findings' }} (advisory, non-blocking)
+            ### kube-linter ${{ steps.lint.outputs.exit_code == '0' && '✅ passed' || '❌ failed' }}
 
-            Checked against the Kubernetes manifests changed in this PR. This is
-            advisory-only for now (see [#115](../../issues/115)) - it does not
-            block merge.
+            Checked against the Kubernetes manifests changed in this PR.
+            Required check - `.kube-linter.yaml` currently enables checks
+            one at a time as the fleet is brought into compliance with each
+            (see [#115](../../issues/115)); it can't yet fail on anything
+            that isn't listed there.
 
             <details><summary>kube-linter output</summary>
 

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,0 +1,48 @@
+# Config for the kube-linter CI job in .github/workflows/pr-validate.yml (#115).
+#
+# Explicitly pins the check set rather than relying on kube-linter's built-in
+# "default" profile, so:
+#   - the actual rules running are reviewable in a diff, not implicit in
+#     whatever version of the binary CI happens to have installed
+#   - a kube-linter upgrade can't silently change what's enforced by
+#     changing its defaults out from under us
+#   - future additions/exclusions (e.g. an exception for a VPN sidecar
+#     needing NET_ADMIN) have one obvious place to go
+#
+# This list is kube-linter v0.8.3's own default-enabled set, reproduced
+# as-is - `kube-linter checks list` shows each check's "Enabled by default"
+# status. No behavior change from the CLI defaults; just made explicit.
+checks:
+  doNotAutoAddDefaults: true
+  include:
+    - dangling-service
+    - deprecated-service-account-field
+    - docker-sock
+    - drop-net-raw-capability
+    - duplicate-env-var
+    - env-var-secret
+    - host-ipc
+    - host-network
+    - host-pid
+    - invalid-target-ports
+    - job-ttl-seconds-after-finished
+    - latest-tag
+    - liveness-port
+    - mismatching-selector
+    - no-anti-affinity
+    - no-extensions-v1beta
+    - no-read-only-root-fs
+    - non-existent-service-account
+    - pdb-max-unavailable
+    - pdb-min-available
+    - pdb-unhealthy-pod-eviction-policy
+    - privilege-escalation-container
+    - privileged-container
+    - readiness-port
+    - run-as-non-root
+    - sensitive-host-mounts
+    - ssh-port
+    - startup-port
+    - unsafe-sysctls
+    - unset-cpu-requirements
+    - unset-memory-requirements

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,15 +1,21 @@
 # Config for the kube-linter CI job in .github/workflows/pr-validate.yml (#115).
 #
-# Deliberately empty for now - kube-linter's own default-enabled checks run
-# as-is (`kube-linter checks list` shows each one's "Enabled by default"
-# status). A bare `--config .kube-linter.yaml` with nothing set here behaves
-# identically to no config at all; this file exists as the one obvious place
-# to add to once we've seen kube-linter's output against real manifests here
-# for a while, e.g.:
+# This job is a required check, but starts with zero checks enabled
+# (doNotAutoAddDefaults: true, empty include) - it passes trivially today by
+# design. The fleet has a real backlog of pre-existing findings (~100+ across
+# services/ and infrastructure/kubernetes), so turning on kube-linter's full
+# default set here on day one would make this required check unpassable
+# until all of that's fixed first.
+#
+# The plan is to add checks to `include` one at a time, each in its own PR
+# that also fixes whatever it finds - so the required check is always real
+# (never advisory, never silently ignorable) and only ever grows in scope
+# once the fleet actually passes it. E.g.:
 #
 #   checks:
+#     doNotAutoAddDefaults: true
 #     include:
-#       - access-to-secrets       # opt into a check that's off by default
+#       - latest-tag              # opted in once #130's fixes landed
 #     exclude:
 #       - no-anti-affinity        # turn off a default check that's too
 #                                 # noisy/not useful for this repo
@@ -17,7 +23,8 @@
 #       - some/generated/path     # skip files that shouldn't be linted
 #
 # The KUBE_LINTER_VERSION pin in pr-validate.yml is tracked by Renovate
-# (see renovate.json) - a version bump PR is the natural point to diff
-# `kube-linter checks list` against this file and decide if anything new
-# is worth opting into.
-checks: {}
+# (see renovate.json) - a version bump PR is a natural point to check
+# `kube-linter checks list` for anything new worth opting into.
+checks:
+  doNotAutoAddDefaults: true
+  include: []

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,48 +1,23 @@
 # Config for the kube-linter CI job in .github/workflows/pr-validate.yml (#115).
 #
-# Explicitly pins the check set rather than relying on kube-linter's built-in
-# "default" profile, so:
-#   - the actual rules running are reviewable in a diff, not implicit in
-#     whatever version of the binary CI happens to have installed
-#   - a kube-linter upgrade can't silently change what's enforced by
-#     changing its defaults out from under us
-#   - future additions/exclusions (e.g. an exception for a VPN sidecar
-#     needing NET_ADMIN) have one obvious place to go
+# Deliberately empty for now - kube-linter's own default-enabled checks run
+# as-is (`kube-linter checks list` shows each one's "Enabled by default"
+# status). A bare `--config .kube-linter.yaml` with nothing set here behaves
+# identically to no config at all; this file exists as the one obvious place
+# to add to once we've seen kube-linter's output against real manifests here
+# for a while, e.g.:
 #
-# This list is kube-linter v0.8.3's own default-enabled set, reproduced
-# as-is - `kube-linter checks list` shows each check's "Enabled by default"
-# status. No behavior change from the CLI defaults; just made explicit.
-checks:
-  doNotAutoAddDefaults: true
-  include:
-    - dangling-service
-    - deprecated-service-account-field
-    - docker-sock
-    - drop-net-raw-capability
-    - duplicate-env-var
-    - env-var-secret
-    - host-ipc
-    - host-network
-    - host-pid
-    - invalid-target-ports
-    - job-ttl-seconds-after-finished
-    - latest-tag
-    - liveness-port
-    - mismatching-selector
-    - no-anti-affinity
-    - no-extensions-v1beta
-    - no-read-only-root-fs
-    - non-existent-service-account
-    - pdb-max-unavailable
-    - pdb-min-available
-    - pdb-unhealthy-pod-eviction-policy
-    - privilege-escalation-container
-    - privileged-container
-    - readiness-port
-    - run-as-non-root
-    - sensitive-host-mounts
-    - ssh-port
-    - startup-port
-    - unsafe-sysctls
-    - unset-cpu-requirements
-    - unset-memory-requirements
+#   checks:
+#     include:
+#       - access-to-secrets       # opt into a check that's off by default
+#     exclude:
+#       - no-anti-affinity        # turn off a default check that's too
+#                                 # noisy/not useful for this repo
+#     ignorePaths:
+#       - some/generated/path     # skip files that shouldn't be linted
+#
+# The KUBE_LINTER_VERSION pin in pr-validate.yml is tracked by Renovate
+# (see renovate.json) - a version bump PR is the natural point to diff
+# `kube-linter checks list` against this file and decide if anything new
+# is worth opting into.
+checks: {}

--- a/renovate.json
+++ b/renovate.json
@@ -44,6 +44,19 @@
       ],
       "depNameTemplate": "siderolabs/talos",
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "description": "Track kube-linter releases (#115) so a version bump surfaces as its own PR - a natural point to diff `kube-linter checks list` against .kube-linter.yaml and decide if anything new default-enabled upstream is worth opting into. Renovate only bumps KUBE_LINTER_VERSION here; KUBE_LINTER_SHA256 right below it still needs updating by hand in the same PR, or the checksum step fails CI.",
+      "managerFilePatterns": [
+        "/^\\.github/workflows/pr-validate\\.yml$/"
+      ],
+      "matchStrings": [
+        "KUBE_LINTER_VERSION: \"(?<currentValue>[0-9.]+)\""
+      ],
+      "depNameTemplate": "stackrox/kube-linter",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
## What

Adds a `kube-linter` job to `.github/workflows/pr-validate.yml`, following the
same pattern as the existing `kubeconform` job (pinned binary + sha256
checksum verification), plus a `.kube-linter.yaml` config file.

## This is a required check, not advisory

The step exits with kube-linter's real exit code - if it finds a violation
in an *enabled* check, the job fails for real, same as `kubeconform` does
today.

`.kube-linter.yaml` starts with `doNotAutoAddDefaults: true` and an empty
`include` list - **zero checks enabled**, so it passes trivially right now.
That's deliberate: the fleet has ~100 pre-existing findings across
`services/` and `infrastructure/kubernetes` (missing `readOnlyRootFilesystem`,
`runAsNonRoot`, resource requests/limits, `:latest` tags, etc.) - turning on
kube-linter's full default set today would make this required check
unpassable until all of that's fixed first.

The plan: opt checks into `include` one at a time, each in its own PR that
also fixes whatever that check finds against the current fleet. The gate is
always real - never silently advisory, never something that can be ignored -
it just only grows in scope once the fleet actually passes what's enabled.
First one up: `latest-tag`, paired with the fixes in #130.

## Scope

Like `kubeconform`, this only lints Kubernetes manifests *changed by the PR*
- the same "changed files only" pattern the `opentofu` job already uses for
`tofu fmt`. A repo-wide sweep would still be useful for catching drift when a
check's scope is later tightened, but that's a separate concern from this
PR's job.

## Other pieces already in place

- `KUBE_LINTER_VERSION` is tracked by a Renovate custom manager
  (`renovate.json`), so a kube-linter release shows up as its own PR - a
  natural point to check `kube-linter checks list` for anything new worth
  opting into. The sha256 checksum still needs updating by hand in that PR,
  same as `kubeconform`'s existing (currently untracked) pin.
- Findings still post as a single upserted PR comment
  (`marocchino/sticky-pull-request-comment`), now updated to reflect
  required-check framing and to post even when the step fails (`always()`).

## Not in scope

Kyverno / live admission control - tracked separately as a deliberately
deferred spike (#117), not part of this rollout.

Closes #115