### PR TITLE
Rename code-for-boston Postgres cluster's namespace to code-for-boston-database

### DIFF
--- a/databases/code-for-boston/postgres/namespace.yaml
+++ b/databases/code-for-boston/postgres/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: code-for-boston
+  name: code-for-boston-database

--- a/databases/code-for-boston/postgres/postgres-cluster.yaml
+++ b/databases/code-for-boston/postgres/postgres-cluster.yaml
@@ -7,7 +7,7 @@ apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
 metadata:
   name: postgres
-  namespace: code-for-boston
+  namespace: code-for-boston-database
 spec:
   instances: 1
   storage:


### PR DESCRIPTION
## What

Renames the namespace from #118's Postgres cluster from `code-for-boston`
to `code-for-boston-database`.

## Why

`code-for-boston` (the tenant) is going to have two namespaces: this
Postgres cluster, and a separate app-tier namespace (in flight on #44,
which currently uses `project-management` but is being renamed to
`code-for-boston` for consistency with `databases/code-for-boston/`).
Both can't have the same name.

Naming rule: a namespace serving many tenants gets a generic name for
its function (like the existing `database` namespace, shared across
jellyfin/signal-messaging/downloads-standard). A namespace serving one
tenant gets that tenant's name, and once a tenant has more than one
namespace, tier distinguishes them. code-for-boston's Postgres cluster
serves exactly one tenant, so it gets `code-for-boston-database`; the
app tier gets the bare `code-for-boston` name, same as
`downloads-standard`/`jellyfin`/`signal-messaging` are named.

## Notes

#44 depends on this merging first — it points at
`code-for-boston-database` instead of the now-renamed namespace.