### PR TITLE
Deploy Leantime for volunteer project-management trial

### DIFF
--- a/infrastructure/cloudflare/opentofu/variables.tf
+++ b/infrastructure/cloudflare/opentofu/variables.tf
@@ -39,6 +39,7 @@ variable "tunnel_hostnames" {
   default = [
     "books-sync",
     "gimme",
+    "leantime",
     "mattflix",
     "pangolin",
     "pangolin-test",

--- a/infrastructure/tunnel/blueprints/leantime.yaml
+++ b/infrastructure/tunnel/blueprints/leantime.yaml
@@ -9,9 +9,7 @@ public-resources:
         hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
         port: 80
     auth:
-      sso-enabled: true
-      sso-roles:
-        - Member
+      sso-enabled: false
     rules:
       - action: deny
         match: path

--- a/infrastructure/tunnel/blueprints/leantime.yaml
+++ b/infrastructure/tunnel/blueprints/leantime.yaml
@@ -11,11 +11,7 @@ public-resources:
     auth:
       sso-enabled: false
     rules:
-      - action: deny
-        match: path
-        value: /metrics
-        priority: 1
       - action: allow
         match: country
         value: US
-        priority: 2
+        priority: 1

--- a/infrastructure/tunnel/blueprints/leantime.yaml
+++ b/infrastructure/tunnel/blueprints/leantime.yaml
@@ -1,0 +1,23 @@
+public-resources:
+  leantime:
+    name: "Leantime"
+    mode: http
+    full-domain: leantime.labmatt.com
+    targets:
+      - site: faithful-brachyurophis-fasciolatus
+        method: http
+        hostname: ingress-nginx-controller.ingress-nginx.svc.cluster.local
+        port: 80
+    auth:
+      sso-enabled: true
+      sso-roles:
+        - Member
+    rules:
+      - action: deny
+        match: path
+        value: /metrics
+        priority: 1
+      - action: allow
+        match: country
+        value: US
+        priority: 2

--- a/infrastructure/tunnel/blueprints/leantime.yaml
+++ b/infrastructure/tunnel/blueprints/leantime.yaml
@@ -10,8 +10,3 @@ public-resources:
         port: 80
     auth:
       sso-enabled: false
-    rules:
-      - action: allow
-        match: country
-        value: US
-        priority: 1

--- a/services/code-for-boston/README.md
+++ b/services/code-for-boston/README.md
@@ -1,0 +1,44 @@
+# code-for-boston
+
+Apps serving the Code for Boston volunteer group, plus the dedicated
+Postgres cluster (`postgres/`) they share. Flux-managed — see
+`clusters/eye-of-michael/flux-system/code-for-boston.yaml` for the
+Kustomization CR that reconciles this path.
+
+## Leantime
+
+Goals-focused project management, for a volunteer-feedback trial
+alongside Wekan (`wekan-trial` branch/PR) in the shared `code-for-boston`
+namespace.
+
+### Dependencies
+
+- The `postgres/` cluster in this directory — a dedicated `leantime`
+  role/database there (least-privilege: just the `leantime` database,
+  not the internal cluster's shared `app` role), plus a matching
+  `pg_hba` line and `code-for-boston` in
+  `reflection-allowed-namespaces`.
+- Pangolin tunnel — `leantime.labmatt.com` is added to `tunnel_hostnames`
+  in `infrastructure/cloudflare/opentofu`.
+
+### Manual steps (not yet automated)
+
+These aren't covered by Flux and need doing once, after merge:
+
+```bash
+kubectl create secret generic leantime-session -n code-for-boston \
+  --from-literal=LEAN_SESSION_PASSWORD=$(openssl rand -hex 32)
+
+kubectl create secret generic leantime-postgres-credentials \
+  -n code-for-boston-database \
+  --from-literal=username=leantime \
+  --from-literal=password=$(openssl rand -hex 32)
+```
+
+Also run `tofu apply` in `infrastructure/cloudflare/opentofu` for the DNS
+record (tracked for automation in #57), and create the matching resource
++ access rule in the Pangolin dashboard per
+`infrastructure/tunnel/blueprints/README.md` (tracked in #7).
+
+First run creates an admin account at first login on
+`leantime.labmatt.com`.

--- a/services/code-for-boston/kustomization.yaml
+++ b/services/code-for-boston/kustomization.yaml
@@ -4,4 +4,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - namespace.yaml
   - postgres
+  - leantime/database.yaml
+  - leantime/secret.yaml
+  - leantime/pvc.yaml
+  - leantime/deployment.yaml
+  - leantime/service.yaml
+  - leantime/ingress.yaml

--- a/services/code-for-boston/leantime/database.yaml
+++ b/services/code-for-boston/leantime/database.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: leantime
+  namespace: code-for-boston-database
+spec:
+  name: leantime
+  owner: leantime
+  cluster:
+    name: postgres

--- a/services/code-for-boston/leantime/deployment.yaml
+++ b/services/code-for-boston/leantime/deployment.yaml
@@ -1,0 +1,78 @@
+# Leantime's session/CSRF secret and DB password both need to survive pod
+# restarts, so LEAN_SESSION_PASSWORD is pinned in this Secret rather than
+# left to the image's default (which regenerates per-container and would
+# invalidate every session on every restart). Create it once:
+#   kubectl create secret generic leantime-session -n code-for-boston \
+#     --from-literal=LEAN_SESSION_PASSWORD=$(openssl rand -hex 32)
+#
+# LEAN_DB_USER/LEAN_DB_PASSWORD come from leantime-postgres-credentials,
+# reflected from the code-for-boston-database cluster - see
+# ../postgres/postgres-cluster.yaml for the dedicated "leantime" role
+# this database.yaml's owner points at.
+# It's scoped to just the leantime database, not the shared "app" role
+# other apps use on the internal cluster.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: leantime
+  namespace: code-for-boston
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: leantime
+  template:
+    metadata:
+      labels:
+        app: leantime
+    spec:
+      containers:
+        - name: leantime
+          image: leantime/leantime:v3.7.3
+          ports:
+            - containerPort: 80
+              name: http
+          env:
+            - name: LEAN_DB_TYPE
+              value: postgres
+            - name: LEAN_DB_HOST
+              value: postgres-rw.code-for-boston-database
+            - name: LEAN_DB_PORT
+              value: "5432"
+            - name: LEAN_DB_DATABASE
+              value: leantime
+            - name: LEAN_DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: leantime-postgres-credentials
+                  key: username
+            - name: LEAN_DB_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: leantime-postgres-credentials
+                  key: password
+            - name: LEAN_SESSION_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: leantime-session
+                  key: LEAN_SESSION_PASSWORD
+            - name: LEAN_APP_URL
+              value: https://leantime.labmatt.com
+          volumeMounts:
+            - name: userfiles
+              mountPath: /var/www/html/public/userfiles
+              subPath: public_userfiles
+            - name: userfiles
+              mountPath: /var/www/html/userfiles
+              subPath: userfiles
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "1000m"
+      volumes:
+        - name: userfiles
+          persistentVolumeClaim:
+            claimName: leantime-userfiles

--- a/services/code-for-boston/leantime/ingress.yaml
+++ b/services/code-for-boston/leantime/ingress.yaml
@@ -1,0 +1,22 @@
+# leantime.labmatt.com is routed through the Pangolin tunnel (see
+# infrastructure/cloudflare/opentofu tunnel_hostnames and
+# infrastructure/tunnel/README.md) so volunteers can reach it from the
+# open internet.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: leantime
+  namespace: code-for-boston
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: leantime.labmatt.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: leantime
+                port:
+                  number: 80

--- a/services/code-for-boston/leantime/pvc.yaml
+++ b/services/code-for-boston/leantime/pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: leantime-userfiles
+  namespace: code-for-boston
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi

--- a/services/code-for-boston/leantime/secret.yaml
+++ b/services/code-for-boston/leantime/secret.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: leantime-postgres-credentials
+  namespace: code-for-boston
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflects: "code-for-boston-database/leantime-postgres-credentials"

--- a/services/code-for-boston/leantime/service.yaml
+++ b/services/code-for-boston/leantime/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: leantime
+  namespace: code-for-boston
+spec:
+  selector:
+    app: leantime
+  ports:
+    - port: 80
+      targetPort: 80

--- a/services/code-for-boston/namespace.yaml
+++ b/services/code-for-boston/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: code-for-boston

--- a/services/code-for-boston/postgres/postgres-cluster.yaml
+++ b/services/code-for-boston/postgres/postgres-cluster.yaml
@@ -13,11 +13,20 @@ spec:
   storage:
     size: 10Gi
     storageClass: nfs-provisioner
+  managed:
+    roles:
+      # One entry per tenant. passwordSecret is created manually (see
+      # services/code-for-boston/README.md for leantime's) rather
+      # than committed to git.
+      - name: leantime
+        ensure: present
+        login: true
+        passwordSecret:
+          name: leantime-postgres-credentials
   postgresql:
     pg_hba:
       # One line per tenant.
-      # e.g.:
-      #   - hostssl leantime leantime_user all scram-sha-256
+      - hostssl leantime leantime all scram-sha-256
       #
       # Catch-all: only tenants listed above get in.
       # CNPG appends its own permissive catch-all after this list.
@@ -26,4 +35,4 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: ""
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "code-for-boston"


### PR DESCRIPTION
## What

Reworks #44 for the org-scoped-vs-cross-cutting DB convention landed in
#120: closes #44, supersedes its branch.

- Single-container app (`leantime/leantime`), no separate worker/queue
  tier needed.
- Joins the existing `code-for-boston` Postgres cluster
  (`services/code-for-boston/postgres`, #118/#119/#120) rather than a
  separate `databases/` tree: adds a `leantime` `Database` CR and a
  least-privilege `leantime` role scoped to just that database, plus a
  matching `pg_hba` line and `code-for-boston` added to the cluster's
  reflector allowed-namespaces so it can pull the
  `leantime-postgres-credentials` secret.
- App namespace and resources join the existing
  `services/code-for-boston` Flux Kustomization instead of introducing
  a new one.
- Exposed publicly via Pangolin at `leantime.labmatt.com`
  (`tunnel_hostnames` in the Cloudflare DNS module for the DNS record,
  `infrastructure/tunnel/blueprints/leantime.yaml` for the Pangolin
  resource/access rule). No country-bypass rule - volunteers aren't
  confined to a few geos, so every request goes through normal SSO
  auth instead.

## Why

Comparing Leantime and Wekan head-to-head with actual volunteer usage
beats guessing which project-management tool fits better up front.

Leantime and its Postgres cluster are named `code-for-boston` (not
`project-management`) because that's the actual organizing axis: it's
apps serving this one volunteer group, not a category of app that
other groups might also want. Wekan is expected to join the same
`code-for-boston` namespace once its PR is similarly updated.

## Deploy

See `services/code-for-boston/README.md` for the full apply order,
including creating the `leantime-session` secret (not generated here
on purpose), running `tofu apply` for the DNS change, and applying the
Pangolin blueprint per its README.