### PR TITLE
Fix leantime image tag: no v prefix on Docker Hub

### DIFF
--- a/services/code-for-boston/leantime/deployment.yaml
+++ b/services/code-for-boston/leantime/deployment.yaml
@@ -28,7 +28,7 @@ spec:
     spec:
       containers:
         - name: leantime
-          image: leantime/leantime:v3.7.3
+          image: leantime/leantime:3.9.8
           ports:
             - containerPort: 80
               name: http


### PR DESCRIPTION
## What

\`leantime/leantime:v3.7.3\` (from #121) doesn't exist - Docker Hub
tags this image without a \`v\` prefix (e.g. \`3.7.3\`, \`3.9.8\`), so
the pod sat in \`ImagePullBackOff\` after deploy. Pinned to \`3.9.8\`,
the current latest stable release, since this is a fresh deploy.

## Verify

Confirmed against the Docker Hub API - \`v3.7.3\` 404s, \`3.9.8\` exists.