### PR TITLE
Fix leantime container port: image listens on 8080, not 80

### DIFF
--- a/services/code-for-boston/leantime/deployment.yaml
+++ b/services/code-for-boston/leantime/deployment.yaml
@@ -30,7 +30,7 @@ spec:
         - name: leantime
           image: leantime/leantime:3.9.8
           ports:
-            - containerPort: 80
+            - containerPort: 8080
               name: http
           env:
             - name: LEAN_DB_TYPE

--- a/services/code-for-boston/leantime/service.yaml
+++ b/services/code-for-boston/leantime/service.yaml
@@ -8,4 +8,4 @@ spec:
     app: leantime
   ports:
     - port: 80
-      targetPort: 80
+      targetPort: 8080


### PR DESCRIPTION
## What

The leantime pod came up Running/Ready (readiness has no probe, so
1/1 doesn't mean serving) but connections to port 80 were refused.
Checked inside the running container:

\`\`\`
tcp   0   0 0.0.0.0:8080   0.0.0.0:*   LISTEN   nginx
\`\`\`

Since v3.4, the official \`leantime/leantime\` image hardened its Docker
setup to run nginx as non-root, which can't bind port 80 - it listens
on 8080 instead (confirmed against the upstream Dockerfile/compose,
which both use 8080).

\`deployment.yaml\`'s \`containerPort\` and \`service.yaml\`'s
\`targetPort\` were both set to 80. Fixed both to 8080 - the Service
still exposes port 80 externally, so nothing downstream (Ingress,
Pangolin blueprint) needs to change.