### PR TITLE
Fully qualify LEAN_DB_HOST for leantime

### DIFF
--- a/services/code-for-boston/leantime/deployment.yaml
+++ b/services/code-for-boston/leantime/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - name: LEAN_DB_TYPE
               value: postgres
             - name: LEAN_DB_HOST
-              value: postgres-rw.code-for-boston-database
+              value: postgres-rw.code-for-boston-database.svc.cluster.local
             - name: LEAN_DB_PORT
               value: "5432"
             - name: LEAN_DB_DATABASE


### PR DESCRIPTION
## What

With the port fix (#123) in, the leantime pod came up healthy but
every HTTP request just hung with no response - PHP-FPM was blocked
on the DB connection. Checked DNS resolution inside the pod:

\`\`\`
$ nslookup postgres-rw.code-for-boston-database
** server can't find postgres-rw.code-for-boston-database: NXDOMAIN

$ nslookup postgres-rw.code-for-boston-database.svc.cluster.local
Address: 10.102.141.254
\`\`\`

The \`leantime/leantime\` image is Alpine (musl libc). musl's resolver,
unlike glibc, doesn't fall through the remaining \`ndots\` search
suffixes once it gets an NXDOMAIN - so the short 2-label cross-namespace
form (\`<service>.<namespace>\`, works fine on glibc-based images) never
resolves here. Fully qualifying \`LEAN_DB_HOST\` fixes it.

## Verify

Confirmed the FQDN resolves correctly inside the running pod; will
verify the app actually responds once this merges and reconciles.