### PR TITLE
Fix wekan-mongo: bind to all interfaces + restrict access via NetworkPolicy

### DIFF
--- a/services/code-for-boston/kustomization.yaml
+++ b/services/code-for-boston/kustomization.yaml
@@ -15,6 +15,7 @@ resources:
   - mongodb/pvc.yaml
   - mongodb/deployment.yaml
   - mongodb/service.yaml
+  - mongodb/networkpolicy.yaml
   - wekan/deployment.yaml
   - wekan/service.yaml
   - wekan/ingress.yaml

--- a/services/code-for-boston/mongodb/deployment.yaml
+++ b/services/code-for-boston/mongodb/deployment.yaml
@@ -22,7 +22,7 @@ spec:
       containers:
         - name: mongo
           image: mongo:7
-          command: ["mongod", "--storageEngine=wiredTiger"]
+          command: ["mongod", "--storageEngine=wiredTiger", "--bind_ip_all"]
           ports:
             - containerPort: 27017
           volumeMounts:

--- a/services/code-for-boston/mongodb/deployment.yaml
+++ b/services/code-for-boston/mongodb/deployment.yaml
@@ -1,7 +1,7 @@
 # Dedicated MongoDB for Wekan only - nothing else in this cluster uses
 # Mongo, so this doesn't join the shared Postgres cluster pattern used
-# elsewhere. No auth configured: it's only reachable in-cluster via the
-# ClusterIP Service below, never exposed through an Ingress.
+# elsewhere. No auth configured, so networkpolicy.yaml (not the absence
+# of an Ingress) is what actually keeps this reachable only from wekan.
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/services/code-for-boston/mongodb/networkpolicy.yaml
+++ b/services/code-for-boston/mongodb/networkpolicy.yaml
@@ -1,0 +1,22 @@
+# wekan-mongo has no auth (see its deployment.yaml comment), so network
+# access IS the access control - restrict it to the one pod that needs
+# it rather than relying on "nothing else looks for it".
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: wekan-mongo
+  namespace: code-for-boston
+spec:
+  podSelector:
+    matchLabels:
+      app: wekan-mongo
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+        - podSelector:
+            matchLabels:
+              app: wekan
+      ports:
+        - port: 27017
+          protocol: TCP


### PR DESCRIPTION
## What

`mongod` defaults to binding only `127.0.0.1`, so the `wekan-mongo`
Service was routing correctly to the pod but nothing was listening on
its actual pod IP - Wekan's every connection attempt got
`ECONNREFUSED`, crashlooping the app.

Adds `--bind_ip_all` to the mongod command so it actually listens where
the Service expects. But `wekan-mongo` has **no auth** (deliberate,
per its deployment.yaml comment - it's meant to be Wekan-only). Binding
to all interfaces without auth means, on its own, any pod in any
namespace in the cluster that can resolve the Service now gets full
unauthenticated read/write access - not just Wekan.

So this also adds a `NetworkPolicy` restricting `wekan-mongo` ingress
to just the `wekan` pod, on port 27017. That makes network reachability
the actual access boundary again, same intent as before this fix, but
enforced rather than assumed. Still no Ingress - unreachable from
outside the cluster either way.

## Why

Caught live: wekan pod was crashlooping with
`MongoNetworkError: connect ECONNREFUSED 10.98.113.149:27017` and
wekan-mongo's own logs said plainly:
`This server is bound to localhost. Remote systems will be unable to connect to this server.`

## Verify

```bash
kubectl logs -n code-for-boston -l app=wekan-mongo | grep 'Listening on'
# should show 0.0.0.0, not 127.0.0.1

# from a pod that isn't wekan, this should now be refused/timeout:
kubectl run -n code-for-boston --rm -it netpol-test --image=busybox --restart=Never -- \
  nc -zv -w3 wekan-mongo 27017
```
