### PR TITLE
Pin downloads-standard :latest images to their current versions

### DIFF
--- a/services/downloads-standard/bazarr/deployment.yaml
+++ b/services/downloads-standard/bazarr/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           mountPath: /config
       containers:
       - name: bazarr
-        image: lscr.io/linuxserver/bazarr:latest
+        image: lscr.io/linuxserver/bazarr:v1.6.0-ls361
         ports:
         - containerPort: 6767
           name: http

--- a/services/downloads-standard/calibre-web-automated/deployment.yaml
+++ b/services/downloads-standard/calibre-web-automated/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: calibre-web-automated
-        image: crocodilestick/calibre-web-automated:latest
+        image: crocodilestick/calibre-web-automated:v4.0.6
         ports:
         - containerPort: 8083
           name: http

--- a/services/downloads-standard/prowlarr/deployment.yaml
+++ b/services/downloads-standard/prowlarr/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: prowlarr-standard
-        image: lscr.io/linuxserver/prowlarr:latest
+        image: lscr.io/linuxserver/prowlarr:2.5.2.5491-ls157
         ports:
         - containerPort: 9696
           name: http

--- a/services/downloads-standard/radarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/radarr-portuguese/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: radarr-portuguese
-        image: lscr.io/linuxserver/radarr:latest
+        image: lscr.io/linuxserver/radarr:6.3.0.10514-ls314
         ports:
         - containerPort: 7878
           name: http

--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           mountPath: /config
       containers:
       - name: radarr-standard
-        image: lscr.io/linuxserver/radarr:latest
+        image: lscr.io/linuxserver/radarr:6.3.0.10514-ls314
         ports:
         - containerPort: 7878
           name: http

--- a/services/downloads-standard/sabnzbd/deployment.yaml
+++ b/services/downloads-standard/sabnzbd/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: sabnzbd-standard
-        image: lscr.io/linuxserver/sabnzbd:latest
+        image: lscr.io/linuxserver/sabnzbd:5.1.2-ls270
         ports:
         - containerPort: 8080
           name: http

--- a/services/downloads-standard/sonarr-anime/deployment.yaml
+++ b/services/downloads-standard/sonarr-anime/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: sonarr-anime
-        image: lscr.io/linuxserver/sonarr:latest
+        image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls322
         ports:
         - containerPort: 8989
           name: http

--- a/services/downloads-standard/sonarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/sonarr-portuguese/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: sonarr-portuguese
-        image: lscr.io/linuxserver/sonarr:latest
+        image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls322
         ports:
         - containerPort: 8989
           name: http


### PR DESCRIPTION
## What

Pins the 8 `:latest`-tagged images in `services/downloads-standard/` to the concrete version each is currently running, resolved from pod logs (LSIO version banner) or a Docker Hub tag lookup against the pod's running digest, and confirmed the tag exists on the registry before writing it:

| Service | Pinned to |
|---|---|
| prowlarr | `2.5.2.5491-ls157` |
| bazarr | `v1.6.0-ls361` (bazarr uniquely keeps a `v` prefix — other LSIO images here don't) |
| sabnzbd | `5.1.2-ls270` |
| radarr | `6.3.0.10514-ls314` |
| radarr-portuguese | `6.3.0.10514-ls314` |
| sonarr-anime | `4.0.19.2979-ls322` |
| sonarr-portuguese | `4.0.19.2979-ls322` |
| calibre-web-automated | `v4.0.6` |

No pod restarts triggered — each pin matches the digest already running, so this is a no-op deploy.

## Why

Part of #12. `:latest` means an unattended pod restart can silently pull a different image with no diff, no changelog, and no rollback path. This closes out the `downloads-standard` portion of that issue (jellystat, newt, and seerr were already pinned in earlier work; `signal-consumer` is still on `:latest` but that directory isn't tracked in git yet, so it's out of scope here).

## Connecting to Renovate

No `renovate.json` changes needed — its `kubernetes`/`flux` managers already glob `services/**.yaml`, and these 8 images fall under the existing "arr stack (minor/patch)" grouping rule for `services/downloads-standard/**`. Renovate will pick up all 8 as trackable dependencies on its next scheduled run; will confirm they appear in the Dependency Dashboard (#3) once that runs.

## Tagging convention

LinuxServer.io images here use `<upstream-version>-ls<build>` (no `v` prefix), except **bazarr**, which keeps a `v` prefix on the upstream version (`v1.6.0-ls361`). `calibre-web-automated` (not an LSIO image) tags releases as `v<semver>`.