### PR TITLE
Fix invalid lookbehind regex breaking every Renovate run

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,7 +40,7 @@
         "/^infrastructure/proxmox/opentofu/locals\\.tf$/"
       ],
       "matchStrings": [
-        "(?<!cluster_secrets_)talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\""
+        "(?:^|\\n)\\s*talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\""
       ],
       "depNameTemplate": "siderolabs/talos",
       "datasourceTemplate": "github-releases"


### PR DESCRIPTION
## What

Renovate's `talos_version` customManager used a negative lookbehind (`(?<!cluster_secrets_)`) to avoid also matching `cluster_secrets_talos_version`. Renovate validates customManager regexes against **re2** (its default regex engine, chosen for ReDoS safety), and re2 doesn't support lookbehind assertions at all — so config validation rejected it and Renovate aborted the *entire* run before scanning a single package file.

Confirmed by manually triggering the CronJob (`kubectl create job --from=cronjob/renovate`):

```
INFO: Found renovate config errors (repository=MattClarke131/project-seeds)
      "errors": [{ "topic": "Configuration Error", "message": "Invalid regExp for customManagers: `(?<!cluster_secrets_)talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\"`" }]
...
result: "config-validation"
```

This means Renovate has likely been failing silently on every run since the Talos-tracking customManager was added — not just for `talos_version`, for everything (config-validation errors abort the whole repo run).

## Fix

Replaced the lookbehind with a line-start anchor — `talos_version` only matches right after a newline (or file start), which `cluster_secrets_talos_version` never satisfies since `cluster_secrets_` precedes it on the same line:

```diff
- "(?<!cluster_secrets_)talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\""
+ "(?:^|\\n)\\s*talos_version\\s*=\\s*\"(?<currentValue>v[0-9.]+)\""
```

Verified against `infrastructure/proxmox/opentofu/locals.tf`: matches only the `talos_version = "v1.13.8"` line, not `cluster_secrets_talos_version = "v1.11.5"`.

## Why

Blocks verifying #12 (the `:latest` image pins) actually took effect in the Dependency Dashboard — no successful Renovate run has completed since this regex was added, so the dashboard is stale. Once this merges, a manual run should complete cleanly and pick up the newly-pinned images.
