### PR TITLE
Add kube-linter CI check + pin downloads-standard images off :latest

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -79,3 +79,34 @@ jobs:
             -schema-location 'https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/{{.Group}}/{{.ResourceKind}}_{{.ResourceAPIVersion}}.json' \
             -ignore-missing-schemas \
             "${files[@]}"
+
+  kubernetes-manifest-lint:
+    name: Kubernetes manifest lint (kube-linter)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install kube-linter
+        env:
+          KUBE_LINTER_VERSION: "0.8.3"
+          KUBE_LINTER_SHA256: "618d299a3e2839c8ca9d86fce0db617be0fba41f0fecbbbfb7fbf1c04299fae1"
+        run: |
+          set -e
+          curl -sSLO "https://github.com/stackrox/kube-linter/releases/download/v${KUBE_LINTER_VERSION}/kube-linter-linux"
+          echo "${KUBE_LINTER_SHA256}  kube-linter-linux" | sha256sum -c -
+          sudo install kube-linter-linux /usr/local/bin/kube-linter
+
+      - name: kube-linter
+        # Advisory for now (see #115) - reports findings without failing the
+        # build, since the fleet already has a backlog of pre-existing
+        # findings to work through before this can block PRs.
+        continue-on-error: true
+        run: |
+          set -e
+          # Same scope as the kubeconform job above.
+          files=()
+          while IFS= read -r -d '' f; do
+            files+=("$f")
+          done < <(find services infrastructure/kubernetes \( -iname "*.yaml" -o -iname "*.yml" \) ! -iname "*values.yaml" ! -iname "*values.yml" -print0)
+
+          kube-linter lint "${files[@]}"

--- a/services/downloads-standard/bazarr/deployment.yaml
+++ b/services/downloads-standard/bazarr/deployment.yaml
@@ -44,7 +44,7 @@ spec:
           mountPath: /config
       containers:
       - name: bazarr
-        image: lscr.io/linuxserver/bazarr:latest
+        image: lscr.io/linuxserver/bazarr:v1.6.0-ls361
         ports:
         - containerPort: 6767
           name: http

--- a/services/downloads-standard/calibre-web-automated/deployment.yaml
+++ b/services/downloads-standard/calibre-web-automated/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: calibre-web-automated
-        image: crocodilestick/calibre-web-automated:latest
+        image: crocodilestick/calibre-web-automated:v4.0.6
         ports:
         - containerPort: 8083
           name: http

--- a/services/downloads-standard/prowlarr/deployment.yaml
+++ b/services/downloads-standard/prowlarr/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: prowlarr-standard
-        image: lscr.io/linuxserver/prowlarr:latest
+        image: lscr.io/linuxserver/prowlarr:2.5.2.5491-ls157
         ports:
         - containerPort: 9696
           name: http

--- a/services/downloads-standard/radarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/radarr-portuguese/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: radarr-portuguese
-        image: lscr.io/linuxserver/radarr:latest
+        image: lscr.io/linuxserver/radarr:6.3.0.10514-ls314
         ports:
         - containerPort: 7878
           name: http

--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -68,7 +68,7 @@ spec:
           mountPath: /config
       containers:
       - name: radarr-standard
-        image: lscr.io/linuxserver/radarr:latest
+        image: lscr.io/linuxserver/radarr:6.3.0.10514-ls314
         ports:
         - containerPort: 7878
           name: http

--- a/services/downloads-standard/sabnzbd/deployment.yaml
+++ b/services/downloads-standard/sabnzbd/deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: sabnzbd-standard
-        image: lscr.io/linuxserver/sabnzbd:latest
+        image: lscr.io/linuxserver/sabnzbd:5.1.2-ls270
         ports:
         - containerPort: 8080
           name: http

--- a/services/downloads-standard/sonarr-anime/deployment.yaml
+++ b/services/downloads-standard/sonarr-anime/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: sonarr-anime
-        image: lscr.io/linuxserver/sonarr:latest
+        image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls322
         ports:
         - containerPort: 8989
           name: http

--- a/services/downloads-standard/sonarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/sonarr-portuguese/deployment.yaml
@@ -67,7 +67,7 @@ spec:
           mountPath: /config
       containers:
       - name: sonarr-portuguese
-        image: lscr.io/linuxserver/sonarr:latest
+        image: lscr.io/linuxserver/sonarr:4.0.19.2979-ls322
         ports:
         - containerPort: 8989
           name: http


### PR DESCRIPTION
## What

- Adds a `kubernetes-manifest-lint` job to `pr-validate.yml` running kube-linter against the same manifest scope as the existing kubeconform job. Advisory for now (`continue-on-error`) - see #115.
- Fixes the first category of findings it surfaced: 8 containers in `downloads-standard` pinned to `:latest`, now pinned to their actual running versions (verified against the live cluster, not guessed) - `prowlarr`, `radarr`, `radarr-portuguese`, `sonarr-anime`, `sonarr-portuguese`, `sabnzbd`, `bazarr`, `calibre-web-automated`.

## Why

`:latest` isn't reproducible - a reschedule or scale event can silently pull different bits than what's actually running, and it's invisible to Renovate's version tracking (#104). `calibre-web-automated` demonstrated this concretely: its running image had already fallen off every published tag, including `:latest` itself, with no stable name attached until this PR (confirmed via registry manifest comparison that it's byte-for-byte `v4.0.6`, not a hidden version bump).

## Verification

- kube-linter run locally against the full manifest tree: `latest-tag` findings went from 8 to 0, total findings 108 to 100.
- Each pin verified against the live cluster's resolved image (`kubectl get pods -o jsonpath=...containerStatuses[*].image/.imageID`) - same bits, just named.
- `calibre-web-automated`'s pin verified via direct registry manifest comparison (same per-architecture digests as the `v4.0.6` tag), not just a version-number guess.

## Follow-up

This is the first of several categories of kube-linter findings being worked through incrementally (resource requests/limits next, then the higher-risk `run-as-non-root`/`no-read-only-root-fs` categories service-by-service). Not enforcing (blocking) yet - tracked to flip once the fleet's backlog is worked through.