### PR TITLE
Enable kube-linter's latest-tag check

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -102,16 +102,28 @@ jobs:
           tar xz -f kube-linter-linux.tar.gz kube-linter
           sudo install kube-linter /usr/local/bin/kube-linter
 
-      - name: kube-linter (changed manifests only)
+      - name: kube-linter
         id: lint
         run: |
           set -e
-          # Only the manifests this PR touches, same as tofu fmt above - not
-          # a repo-wide sweep, so pre-existing findings elsewhere don't fail
-          # an unrelated PR.
-          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- \
-            'services/*.yaml' 'services/*.yml' 'infrastructure/kubernetes/*.yaml' 'infrastructure/kubernetes/*.yml' \
-            ':(exclude)*values.yaml' ':(exclude)*values.yml')
+          # If the ruleset itself changed, a diff-scoped run wouldn't catch
+          # pre-existing violations of a newly-enabled check elsewhere in the
+          # fleet - so that needs every manifest, not just what this PR
+          # touches. Otherwise, only the manifests this PR touches, same as
+          # tofu fmt above, so pre-existing findings elsewhere don't fail an
+          # unrelated PR.
+          config_changed=$(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- .kube-linter.yaml)
+          if [ -n "$config_changed" ]; then
+            echo ".kube-linter.yaml changed - checking the full manifest tree"
+            files=()
+            while IFS= read -r -d '' f; do
+              files+=("$f")
+            done < <(find services infrastructure/kubernetes \( -iname "*.yaml" -o -iname "*.yml" \) ! -iname "*values.yaml" ! -iname "*values.yml" -print0)
+          else
+            mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- \
+              'services/*.yaml' 'services/*.yml' 'infrastructure/kubernetes/*.yaml' 'infrastructure/kubernetes/*.yml' \
+              ':(exclude)*values.yaml' ':(exclude)*values.yml')
+          fi
 
           echo "files_changed=$([ "${#files[@]}" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           if [ "${#files[@]}" -eq 0 ]; then

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -106,9 +106,9 @@ jobs:
         id: lint
         run: |
           set -e
-          # Scoped to manifests this PR touches, same as tofu fmt above -
-          # repo-wide has ~100 pre-existing findings today, so a full sweep
-          # would drown every PR in noise unrelated to what it's changing.
+          # Only the manifests this PR touches, same as tofu fmt above - not
+          # a repo-wide sweep, so pre-existing findings elsewhere don't fail
+          # an unrelated PR.
           mapfile -t files < <(git diff --name-only --diff-filter=ACMR "${{ github.event.pull_request.base.sha }}" HEAD -- \
             'services/*.yaml' 'services/*.yml' 'infrastructure/kubernetes/*.yaml' 'infrastructure/kubernetes/*.yml' \
             ':(exclude)*values.yaml' ':(exclude)*values.yml')
@@ -133,10 +133,6 @@ jobs:
             echo "KUBE_LINTER_EOF"
           } >> "$GITHUB_OUTPUT"
 
-          # Required check, not advisory - .kube-linter.yaml starts with zero
-          # checks enabled (doNotAutoAddDefaults: true), so this passes
-          # trivially until checks are opted in one at a time, each paired
-          # with the fixes for whatever it finds. See #115/#116.
           exit "$exit_code"
 
       - name: Comment findings on PR

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -1,27 +1,7 @@
-# Config for the kube-linter CI job in .github/workflows/pr-validate.yml (#115).
+# Config for the kube-linter CI job in .github/workflows/pr-validate.yml.
 #
-# This job is a required check, but starts with zero checks enabled
-# (doNotAutoAddDefaults: true, empty include) - it passes trivially today by
-# design. The fleet has a real backlog of pre-existing findings (~100+ across
-# services/ and infrastructure/kubernetes), so turning on kube-linter's full
-# default set here on day one would make this required check unpassable
-# until all of that's fixed first.
-#
-# The plan is to add checks to `include` one at a time, each in its own PR
-# that also fixes whatever it finds - so the required check is always real
-# (never advisory, never silently ignorable) and only ever grows in scope
-# once the fleet actually passes it. `latest-tag` is the first one enabled
-# below (its fixes landed in #128, before this repo checked for it). Further
-# opt-ins look like:
-#
-#     exclude:
-#       - no-anti-affinity        # turn off a default check that's too
-#                                 # noisy/not useful for this repo
-#     ignorePaths:
-#       - some/generated/path     # skip files that shouldn't be linted
-#
-# The KUBE_LINTER_VERSION pin in pr-validate.yml is tracked by Renovate
-# (see renovate.json) - a version bump PR is a natural point to check
+# The KUBE_LINTER_VERSION pin there is tracked by Renovate (see
+# renovate.json) - a version bump PR is a natural point to check
 # `kube-linter checks list` for anything new worth opting into.
 checks:
   doNotAutoAddDefaults: true

--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -10,12 +10,10 @@
 # The plan is to add checks to `include` one at a time, each in its own PR
 # that also fixes whatever it finds - so the required check is always real
 # (never advisory, never silently ignorable) and only ever grows in scope
-# once the fleet actually passes it. E.g.:
+# once the fleet actually passes it. `latest-tag` is the first one enabled
+# below (its fixes landed in #128, before this repo checked for it). Further
+# opt-ins look like:
 #
-#   checks:
-#     doNotAutoAddDefaults: true
-#     include:
-#       - latest-tag              # opted in once #130's fixes landed
 #     exclude:
 #       - no-anti-affinity        # turn off a default check that's too
 #                                 # noisy/not useful for this repo
@@ -27,4 +25,5 @@
 # `kube-linter checks list` for anything new worth opting into.
 checks:
   doNotAutoAddDefaults: true
-  include: []
+  include:
+    - latest-tag


### PR DESCRIPTION
## What

Adds `latest-tag` to `.kube-linter.yaml`'s `include` list - the first check enabled on the required gate added in #116.

## Why it's safe to enable now

The fixes already landed in #128 (before this repo was checking for it) - every image in `services/` and `infrastructure/kubernetes` is already pinned off `:latest`. Verified with a full-tree run before opening this PR:

```
$ kube-linter lint --config .kube-linter.yaml services infrastructure/kubernetes
No lint errors found!
```

No manifest changes in this PR - just the config flip, now actually enforced (a regression back to `:latest` on any changed manifest will fail the required check going forward).