### PR TITLE
Enable kube-linter's job-ttl-seconds-after-finished check

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -7,3 +7,4 @@ checks:
   doNotAutoAddDefaults: true
   include:
     - latest-tag
+    - job-ttl-seconds-after-finished

--- a/infrastructure/kubernetes/ci-cd/renovate/cronjob.yaml
+++ b/infrastructure/kubernetes/ci-cd/renovate/cronjob.yaml
@@ -10,7 +10,6 @@ spec:
   failedJobsHistoryLimit: 3
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: Never

--- a/services/downloads-standard/recyclarr/cronjob.yaml
+++ b/services/downloads-standard/recyclarr/cronjob.yaml
@@ -10,7 +10,6 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: Never

--- a/services/downloads-standard/upgrade-search/cronjob.yaml
+++ b/services/downloads-standard/upgrade-search/cronjob.yaml
@@ -10,7 +10,6 @@ spec:
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
-      ttlSecondsAfterFinished: 86400
       template:
         spec:
           restartPolicy: Never


### PR DESCRIPTION
## What

Second item from #134's checklist: `job-ttl-seconds-after-finished` (3 findings).

Three CronJobs (renovate, recyclarr, upgrade-search) set `ttlSecondsAfterFinished`
at the Job level, which kube-linter flags because it can conflict with the
CronJob's own `successfulJobsHistoryLimit`/`failedJobsHistoryLimit` cleanup -
the two mechanisms fight over when a finished job actually gets removed, and
the stricter one wins unpredictably.

All three already set history limits (1-3), so the TTL was redundant. Removed
it and enabled the check in `.kube-linter.yaml`.

Verified zero findings for this check across the whole manifest tree
(`kube-linter lint services infrastructure/kubernetes`) before enabling.

## Not in scope here

The rest of #134's checklist (unset-cpu/memory-requirements, no-anti-affinity/
dangling-service, run-as-non-root/no-read-only-root-fs).