### PR TITLE
Enable kube-linter's no-anti-affinity and dangling-service checks

### DIFF
--- a/.kube-linter.yaml
+++ b/.kube-linter.yaml
@@ -8,3 +8,5 @@ checks:
   include:
     - latest-tag
     - job-ttl-seconds-after-finished
+    - no-anti-affinity
+    - dangling-service

--- a/infrastructure/kubernetes/ingress/test-ingress.yaml
+++ b/infrastructure/kubernetes/ingress/test-ingress.yaml
@@ -10,7 +10,7 @@ metadata:
   name: hello-world
   namespace: test-ingress
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: hello-world

--- a/services/jellyfin/ingress-block-metrics.yaml
+++ b/services/jellyfin/ingress-block-metrics.yaml
@@ -24,6 +24,8 @@ kind: Service
 metadata:
   name: jellyfin-metrics-block
   namespace: jellyfin
+  annotations:
+    ignore-check.kube-linter.io/dangling-service: "no selector is intentional - see file header comment"
 spec:
   ports:
     - port: 80


### PR DESCRIPTION
## What

Third item from #134's checklist: `no-anti-affinity` / `dangling-service` (2 findings).

- **`no-anti-affinity`** on `test-ingress/hello-world` (the only >1-replica
  Deployment in the fleet outside operator-managed CRDs): it's a disposable
  test fixture for the Pangolin ingress path with no real HA requirement, so
  dropped it from 2 replicas to 1 rather than adding an anti-affinity rule
  it doesn't actually need.
- **`dangling-service`** on `jellyfin-metrics-block`: a deliberate
  no-selector Service (see the file's header comment) used to make nginx
  return 503 for Jellyfin's unauthenticated `/metrics` on the
  internet-facing host, since `configuration-snippet` is disabled
  cluster-wide by the ingress-nginx admission webhook. This is a real
  security control, not an oversight, so suppressed the finding via
  `ignore-check.kube-linter.io/dangling-service` rather than changing the
  manifest.

Verified zero findings across the whole manifest tree
(`kube-linter lint services infrastructure/kubernetes`) before enabling
both checks.

## Not in scope here

The rest of #134's checklist: `unset-cpu-requirements`/
`unset-memory-requirements` (deferred - want real Prometheus usage data to
size against, see issue comment) and `run-as-non-root`/`no-read-only-root-fs`.