### PR TITLE
Add TLS certs for jellyfin.labmatt.com and jellystat.labmatt.com

### DIFF
--- a/services/jellyfin/helmrelease.yaml
+++ b/services/jellyfin/helmrelease.yaml
@@ -40,17 +40,6 @@ spec:
       type: ClusterIP
       port: 8096
 
-    # jellyfin.labmatt.com (LAN-only) is intentionally NOT listed here -
-    # it lives on its own Ingress (ingress-lan-tls.yaml) instead, so it can
-    # carry a TLS cert + force-ssl-redirect without forcing HTTPS on
-    # mattflix.labmatt.com too. mattflix is Pangolin-fronted and Newt only
-    # ever sends it plain HTTP - force-ssl-redirect on that host 308s
-    # Newt's request instead of serving content (confirmed break, see
-    # ingress-books-sync.yaml's comment for the same failure on a
-    # different service). ingress-nginx annotations apply per-Ingress
-    # object, not per-host, so the two hosts can't safely share one
-    # Ingress once jellyfin.labmatt.com needs a redirect and mattflix.
-    # labmatt.com must not have one. See issue #10.
     ingress:
       enabled: true
       className: nginx

--- a/services/jellyfin/helmrelease.yaml
+++ b/services/jellyfin/helmrelease.yaml
@@ -40,14 +40,21 @@ spec:
       type: ClusterIP
       port: 8096
 
+    # jellyfin.labmatt.com (LAN-only) is intentionally NOT listed here -
+    # it lives on its own Ingress (ingress-lan-tls.yaml) instead, so it can
+    # carry a TLS cert + force-ssl-redirect without forcing HTTPS on
+    # mattflix.labmatt.com too. mattflix is Pangolin-fronted and Newt only
+    # ever sends it plain HTTP - force-ssl-redirect on that host 308s
+    # Newt's request instead of serving content (confirmed break, see
+    # ingress-books-sync.yaml's comment for the same failure on a
+    # different service). ingress-nginx annotations apply per-Ingress
+    # object, not per-host, so the two hosts can't safely share one
+    # Ingress once jellyfin.labmatt.com needs a redirect and mattflix.
+    # labmatt.com must not have one. See issue #10.
     ingress:
       enabled: true
       className: nginx
       hosts:
-        - host: jellyfin.labmatt.com
-          paths:
-            - path: /
-              pathType: Prefix
         - host: mattflix.labmatt.com
           paths:
             - path: /

--- a/services/jellyfin/ingress-lan-tls.yaml
+++ b/services/jellyfin/ingress-lan-tls.yaml
@@ -1,17 +1,4 @@
-# Standalone Ingress for jellyfin.labmatt.com (LAN-only - resolves to
-# ingress-nginx's internal LoadBalancer IP, never internet-reachable; see
-# ingress-block-metrics.yaml for the DNS split with mattflix.labmatt.com).
-#
-# Split out from the main jellyfin Ingress (helmrelease.yaml) on purpose:
-# jellyfin.labmatt.com is reached directly by LAN clients, so it benefits
-# from a real TLS cert. mattflix.labmatt.com, the other host on the
-# jellyfin service, is Pangolin-fronted - TLS terminates at the
-# Pangolin/Traefik edge, and Newt tunnels plain HTTP to ingress-nginx from
-# there. force-ssl-redirect below would 308 those plain-HTTP Newt
-# requests instead of serving content (same failure already hit on
-# books-sync, see ingress-books-sync.yaml), and ingress-nginx annotations
-# apply per-Ingress-object rather than per-host, so this host can't carry
-# a redirect while sharing an Ingress with mattflix. See issue #10.
+# Standalone Ingress (split out from helmrelease.yaml) so jellyfin.labmatt.com - reached only over the private/LAN network - can get a real TLS cert without forcing a redirect on mattflix.labmatt.com's plain-HTTP Newt traffic. See issue #10.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/services/jellyfin/ingress-lan-tls.yaml
+++ b/services/jellyfin/ingress-lan-tls.yaml
@@ -1,5 +1,5 @@
-# Standalone Ingress split out from helmrelease.yaml, intended to be
-# reached only over private networks (LAN, Tailnet)
+# Standalone Ingress split out from helmrelease.yaml.
+# Intended to be reached only over private networks (LAN, Tailnet)
 #See issue #10
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/services/jellyfin/ingress-lan-tls.yaml
+++ b/services/jellyfin/ingress-lan-tls.yaml
@@ -1,4 +1,7 @@
-# Standalone Ingress (split out from helmrelease.yaml) so jellyfin.labmatt.com - reached only over the private/LAN network - can get a real TLS cert without forcing a redirect on mattflix.labmatt.com's plain-HTTP Newt traffic. See issue #10.
+# Standalone Ingress split out from helmrelease.yaml, intended to be
+# reached only over private networks (LAN, Tailnet) - so it can carry a
+# real TLS cert without forcing a redirect on mattflix.labmatt.com's
+# plain-HTTP Newt traffic. See issue #10.
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/services/jellyfin/ingress-lan-tls.yaml
+++ b/services/jellyfin/ingress-lan-tls.yaml
@@ -1,0 +1,39 @@
+# Standalone Ingress for jellyfin.labmatt.com (LAN-only - resolves to
+# ingress-nginx's internal LoadBalancer IP, never internet-reachable; see
+# ingress-block-metrics.yaml for the DNS split with mattflix.labmatt.com).
+#
+# Split out from the main jellyfin Ingress (helmrelease.yaml) on purpose:
+# jellyfin.labmatt.com is reached directly by LAN clients, so it benefits
+# from a real TLS cert. mattflix.labmatt.com, the other host on the
+# jellyfin service, is Pangolin-fronted - TLS terminates at the
+# Pangolin/Traefik edge, and Newt tunnels plain HTTP to ingress-nginx from
+# there. force-ssl-redirect below would 308 those plain-HTTP Newt
+# requests instead of serving content (same failure already hit on
+# books-sync, see ingress-books-sync.yaml), and ingress-nginx annotations
+# apply per-Ingress-object rather than per-host, so this host can't carry
+# a redirect while sharing an Ingress with mattflix. See issue #10.
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: jellyfin-lan-tls
+  namespace: jellyfin
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - jellyfin.labmatt.com
+      secretName: jellyfin-lan-tls
+  rules:
+    - host: jellyfin.labmatt.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: jellyfin
+                port:
+                  number: 8096

--- a/services/jellyfin/ingress-lan-tls.yaml
+++ b/services/jellyfin/ingress-lan-tls.yaml
@@ -1,7 +1,6 @@
 # Standalone Ingress split out from helmrelease.yaml, intended to be
-# reached only over private networks (LAN, Tailnet) - so it can carry a
-# real TLS cert without forcing a redirect on mattflix.labmatt.com's
-# plain-HTTP Newt traffic. See issue #10.
+# reached only over private networks (LAN, Tailnet)
+#See issue #10
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/services/jellystat/ingress.yaml
+++ b/services/jellystat/ingress.yaml
@@ -5,8 +5,14 @@ metadata:
   namespace: jellyfin
   annotations:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
 spec:
   ingressClassName: nginx
+  tls:
+    - hosts:
+        - jellystat.labmatt.com
+      secretName: jellystat-tls
   rules:
     - host: jellystat.labmatt.com
       http:


### PR DESCRIPTION
## What

- Splits `jellyfin.labmatt.com` off the chart-managed jellyfin Ingress onto its own standalone Ingress with a cert-manager cert + `force-ssl-redirect`.
- Adds a cert-manager cert + `force-ssl-redirect` directly to the existing `jellystat.labmatt.com` Ingress.

## Why

Both hosts are LAN-only and reached directly by clients (not through Pangolin), so they're hosts that actually benefit from TLS - see discussion on #10.

`jellyfin.labmatt.com` has to live on a separate Ingress object rather than just adding `tls:`/`force-ssl-redirect` to the existing shared one: that Ingress also serves `mattflix.labmatt.com`, which is Pangolin-fronted (TLS terminates at the Pangolin/Traefik edge, Newt tunnels plain HTTP internally). `force-ssl-redirect` applies per-Ingress-object, not per-host, so setting it there would 308 Newt's plain-HTTP requests to mattflix instead of serving content - the same failure already documented in `ingress-books-sync.yaml`'s comment for a different service.

`jellystat.labmatt.com` doesn't have this problem - it's not Pangolin-fronted and already sits on its own single-host Ingress, so the annotation was added in place.

## Scope

This does not add TLS to `mattflix.labmatt.com`/`gimme.labmatt.com` - see the comment on #10 for why that part of the original ticket isn't worth doing as scoped.

Closes #10.