### PR TITLE
Expose etcd metrics port, extending ADR 003 to etcd

### DIFF
--- a/docs/adr/003-control-plane-metrics-exposure.md
+++ b/docs/adr/003-control-plane-metrics-exposure.md
@@ -1,7 +1,7 @@
-# ADR: Control-Plane Metrics Exposure (kube-scheduler / kube-controller-manager / kube-proxy)
+# ADR: Control-Plane Metrics Exposure (kube-scheduler / kube-controller-manager / kube-proxy / etcd)
 
 ## Date
-2026-08-21
+2026-08-21 (etcd added 2026-09-01)
 
 ## Status
 Accepted
@@ -96,3 +96,42 @@ conclusion.
 Rejected - these three components are important enough that losing real
 visibility into their health isn't worth avoiding a cheap, well-precedented
 fix. See Context above.
+
+## Addendum: etcd (2026-09-01)
+Same problem, same fix, one more component. Investigating a live Jellyfin
+playback stutter traced back to [[project_observability_rollout_safety]]
+(issue #125's etcd-overload cascade, recurring for the third time - see
+that issue for the incident history) - but with no `etcd_disk_wal_fsync_
+duration_seconds` / `etcd_disk_backend_commit_duration_seconds` data
+available, there was no way to tell whether the recurring timeouts trace to
+actual disk latency or to etcd's own request pattern, only host-level
+proxies (disk busy%, CPU steal) that stayed flat through the exact
+timeout window.
+
+Talos binds etcd's `--listen-metrics-urls` to loopback by default same as
+the other three, for the same reason. Extended `cluster.etcd.extraArgs` in
+`infrastructure/proxmox/opentofu/cluster.tf` alongside the existing three:
+
+```yaml
+cluster:
+  etcd:
+    extraArgs:
+      listen-metrics-urls: http://0.0.0.0:2381
+```
+
+Same risk acceptance as the rest of this ADR: LAN-reachable, unauthenticated,
+operational telemetry only (no secrets, no write access - this is
+`--listen-metrics-urls`, not `--listen-client-urls`). `docs/reconsider-if.md`'s
+existing trigger for this ADR now covers etcd too.
+
+Prometheus scrape config added to `kube-prometheus-stack`'s `helmrelease.yaml`
+as a new `etcd` job, reusing the existing `prometheus-targets.json` file_sd
+source (filtered to `role: control_plane`, address rewritten to port 2381)
+rather than adding a second target file.
+
+**Rollout is code-only as of this addendum** - `cluster.tf`'s
+`data.talos_machine_configuration` only affects new/recreated VMs; getting
+this onto the three already-running control-plane nodes needs a live
+`talosctl apply-config` per node (same as the original three did), applied
+one node at a time with an `etcd status`/quorum check between each given
+etcd is the exact component already showing instability. Not yet run.

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -62,6 +62,30 @@ spec:
                 target_label: host
               - source_labels: [role]
                 target_label: role
+          # Reuses the same target file as node-exporter (control_plane-role
+          # entries only), rewritten to etcd's metrics port. Talos binds
+          # etcd's --listen-metrics-urls to 127.0.0.1 by default - see
+          # docs/adr/003-control-plane-metrics-exposure.md, which this
+          # extends to etcd's own listen-metrics-urls (0.0.0.0:2381).
+          # Unauthenticated by design, same accepted tradeoff as that ADR.
+          - job_name: 'etcd'
+            file_sd_configs:
+              - files:
+                  - /etc/prometheus/configmaps/prometheus-targets/prometheus-targets.json
+            relabel_configs:
+              - source_labels: [role]
+                regex: control_plane
+                action: keep
+              - source_labels: [__address__]
+                regex: '([^:]+):.*'
+                target_label: __address__
+                replacement: '${1}:2381'
+              - source_labels: [__address__]
+                target_label: instance
+              - source_labels: [hostname]
+                target_label: hostname
+              - source_labels: [host]
+                target_label: host
         storageSpec:
           volumeClaimTemplate:
             spec:

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -100,6 +100,11 @@ data "talos_machine_configuration" "controlplane" {
             "metrics-bind-address" = "0.0.0.0:10249"
           }
         }
+        etcd = {
+          extraArgs = {
+            "listen-metrics-urls" = "http://0.0.0.0:2381"
+          }
+        }
       }
     })
   ]


### PR DESCRIPTION
## What
Extends ADR 003 (control-plane metrics exposure) to etcd, which Talos also binds to loopback by default (`--listen-metrics-urls`). Adds:
- `cluster.etcd.extraArgs.listen-metrics-urls = http://0.0.0.0:2381` in `cluster.tf`, same pattern/risk acceptance as the existing scheduler/controller-manager/proxy entries.
- A new `etcd` Prometheus scrape job in `kube-prometheus-stack`'s `helmrelease.yaml`, reusing the existing `prometheus-targets.json` file_sd source (control_plane-role entries, port rewritten to 2381) rather than a second target file.
- An addendum to ADR 003 documenting why.

## Why
Investigating tonight's Jellyfin stream stutter traced back to the recurring etcd-overload cascade tracked in issue #125. Host-level proxies (disk busy%, CPU steal on the etcd leader's host) stayed completely flat through the exact window etcd was timing out - meaning there was no way to tell whether the timeouts trace to real disk/fsync latency or to etcd's own request pattern. This closes that visibility gap so the next recurrence has real data instead of another round of proxy-metric guessing.

## Rollout
Code-only in this PR - `cluster.tf`'s machine configuration only affects new/recreated VMs. The live rollout onto the three already-running control-plane nodes (`talosctl apply-config`, one node at a time with an etcd status/quorum check between each) is being done separately tonight, not through this PR, given etcd is the exact component currently showing instability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)