### PR TITLE
Note etcd metrics rollout as complete in ADR 003

### DIFF
--- a/docs/adr/003-control-plane-metrics-exposure.md
+++ b/docs/adr/003-control-plane-metrics-exposure.md
@@ -129,20 +129,10 @@ as a new `etcd` job, reusing the existing `prometheus-targets.json` file_sd
 source (filtered to `role: control_plane`, address rewritten to port 2381)
 rather than adding a second target file.
 
-**Rollout complete (2026-09-01, same night).** `cluster.tf`'s
-`data.talos_machine_configuration` only affects new/recreated VMs, so the
-three already-running control-plane nodes each needed a live
-`talosctl patch mc` (not `apply-config` - etcd doesn't support a plain
-service restart via the Talos API, `rpc error: ... service "etcd" doesn't
-support restart operation via API`) followed by a full node reboot to
-actually bounce the etcd process and pick up the new arg. Done one node at
-a time - `livio-cp` first, then `nicholas-cp`, then `razlo-cp` (the etcd
-leader at the time, so its reboot triggered one leader election, expected
-and harmless) - verifying quorum (`etcd status`/`etcd members`) and the
-metrics port (`curl .../2381/metrics`) after each before moving to the
-next. All three confirmed `up` in Prometheus's `etcd` job afterward, with
-`etcd_disk_wal_fsync_duration_seconds` actively incrementing on all three.
-Quorum stayed healthy throughout (3 members, no missed elections beyond
-the one expected one). Jellyfin playback (running on a worker VM, not any
-of the rebooted control-plane VMs) was unaffected by any of the three
-reboots.
+**Rollout complete (2026-09-01).** Applying this to a running control
+plane needs a full node reboot, not just `talosctl patch mc`/`apply-config`
+- etcd refuses a plain service restart via the Talos API
+(`rpc error: ... service "etcd" doesn't support restart operation via
+API`), so the config change alone doesn't bounce the process. All three
+control planes are confirmed `up` in Prometheus's `etcd` job with
+`etcd_disk_wal_fsync_duration_seconds` incrementing.

--- a/docs/adr/003-control-plane-metrics-exposure.md
+++ b/docs/adr/003-control-plane-metrics-exposure.md
@@ -128,11 +128,3 @@ Prometheus scrape config added to `kube-prometheus-stack`'s `helmrelease.yaml`
 as a new `etcd` job, reusing the existing `prometheus-targets.json` file_sd
 source (filtered to `role: control_plane`, address rewritten to port 2381)
 rather than adding a second target file.
-
-**Rollout complete (2026-09-01).** Applying this to a running control
-plane needs a full node reboot, not just `talosctl patch mc`/`apply-config`
-- etcd refuses a plain service restart via the Talos API
-(`rpc error: ... service "etcd" doesn't support restart operation via
-API`), so the config change alone doesn't bounce the process. All three
-control planes are confirmed `up` in Prometheus's `etcd` job with
-`etcd_disk_wal_fsync_duration_seconds` incrementing.

--- a/docs/adr/003-control-plane-metrics-exposure.md
+++ b/docs/adr/003-control-plane-metrics-exposure.md
@@ -129,9 +129,20 @@ as a new `etcd` job, reusing the existing `prometheus-targets.json` file_sd
 source (filtered to `role: control_plane`, address rewritten to port 2381)
 rather than adding a second target file.
 
-**Rollout is code-only as of this addendum** - `cluster.tf`'s
-`data.talos_machine_configuration` only affects new/recreated VMs; getting
-this onto the three already-running control-plane nodes needs a live
-`talosctl apply-config` per node (same as the original three did), applied
-one node at a time with an `etcd status`/quorum check between each given
-etcd is the exact component already showing instability. Not yet run.
+**Rollout complete (2026-09-01, same night).** `cluster.tf`'s
+`data.talos_machine_configuration` only affects new/recreated VMs, so the
+three already-running control-plane nodes each needed a live
+`talosctl patch mc` (not `apply-config` - etcd doesn't support a plain
+service restart via the Talos API, `rpc error: ... service "etcd" doesn't
+support restart operation via API`) followed by a full node reboot to
+actually bounce the etcd process and pick up the new arg. Done one node at
+a time - `livio-cp` first, then `nicholas-cp`, then `razlo-cp` (the etcd
+leader at the time, so its reboot triggered one leader election, expected
+and harmless) - verifying quorum (`etcd status`/`etcd members`) and the
+metrics port (`curl .../2381/metrics`) after each before moving to the
+next. All three confirmed `up` in Prometheus's `etcd` job afterward, with
+`etcd_disk_wal_fsync_duration_seconds` actively incrementing on all three.
+Quorum stayed healthy throughout (3 members, no missed elections beyond
+the one expected one). Jellyfin playback (running on a worker VM, not any
+of the rebooted control-plane VMs) was unaffected by any of the three
+reboots.

--- a/infrastructure/kubernetes/observability/dashboards/etcd-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/etcd-overview.yaml
@@ -1,0 +1,326 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: etcd-overview
+  namespace: observability
+  creationTimestamp: null
+  labels:
+    grafana_dashboard: "1"
+  annotations:
+    grafana_folder: "Infrastructure"
+data:
+  etcd-overview.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "grafana",
+              "uid": "-- Grafana --"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "etcd's own disk-latency metrics (WAL fsync / backend commit duration), scraped via the etcd job added in docs/adr/003-control-plane-metrics-exposure.md. Built to close the visibility gap found investigating issue #125 (recurring etcd-overload/NotReady flapping) - host-level proxies (disk busy%, CPU steal) stayed flat through those incidents, so this is the metric that actually shows whether etcd's write path is slow. Thresholds (10ms fsync p99, 25ms backend commit p99) are etcd's own documented healthy-cluster guidance, not a value tuned to this cluster.",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "graphTooltip": 0,
+      "id": null,
+      "links": [],
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "p99 WAL fsync latency per control-plane node. etcd's own guidance: healthy clusters stay under 10ms (the red threshold here); sustained higher values mean the disk backing etcd can't keep up with its write load.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.01
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 1,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job=\"etcd\"}[5m])))",
+              "legendFormat": "{{hostname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "WAL fsync duration (p99)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "p99 backend commit latency per control-plane node. etcd's own guidance: healthy clusters stay under 25ms (the red threshold here); this is the other half of etcd's write path alongside WAL fsync above.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "line"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.025
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 24,
+            "x": 0,
+            "y": 9
+          },
+          "id": 2,
+          "options": {
+            "legend": {
+              "calcs": [
+                "mean",
+                "max"
+              ],
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "multi",
+              "sort": "desc"
+            }
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "expr": "histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job=\"etcd\"}[5m])))",
+              "legendFormat": "{{hostname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Backend commit duration (p99)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "description": "Which control-plane node etcd's raft leader is currently on. Leader handles all writes, so its disk latency matters most - useful to cross-reference against the two panels above when tracking down a spike.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "text": "follower"
+                    },
+                    "1": {
+                      "text": "leader"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "text",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 24,
+            "x": 0,
+            "y": 18
+          },
+          "id": 3,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "name_and_value"
+          },
+          "pluginVersion": "10.0.3",
+          "targets": [
+            {
+              "expr": "etcd_server_is_leader{job=\"etcd\"}",
+              "legendFormat": "{{hostname}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Raft leader",
+          "type": "stat"
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 38,
+      "style": "dark",
+      "tags": [
+        "etcd",
+        "infrastructure"
+      ],
+      "templating": {
+        "list": []
+      },
+      "time": {
+        "from": "now-6h",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "etcd Overview",
+      "uid": "etcd-overview",
+      "version": 1,
+      "weekStart": ""
+    }

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -88,3 +88,44 @@ spec:
             description: >-
               Jellyfin is throwing exceptions at {{ printf "%.2f" $value }}/s,
               more than 3x its trailing 1-hour average, for 5 minutes.
+
+    - name: custom-etcd-latency
+      rules:
+        # Scraped via the etcd job added alongside docs/adr/003-control-
+        # plane-metrics-exposure.md's etcd addendum - see etcd-overview
+        # Grafana dashboard for the panels these mirror. Thresholds (10ms
+        # fsync p99, 25ms backend commit p99) are etcd's own documented
+        # healthy-cluster guidance, not values tuned to this cluster.
+        #
+        # Built investigating issue #125 (recurring etcd-overload/NotReady
+        # flapping, one recurrence causing a live Jellyfin stutter) - host-
+        # level proxies (disk busy%, CPU steal) stayed flat through that
+        # incident, so these are the metrics that would have actually shown
+        # whether it was real disk latency.
+        - alert: EtcdHighFsyncDuration
+          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 0.01
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "etcd WAL fsync latency is above etcd's healthy-cluster guidance."
+            description: >-
+              {{ $labels.hostname }}'s etcd WAL fsync p99 has been above
+              10ms for 10 minutes, is currently
+              {{ printf "%.1f" (mul $value 1000) }}ms. This is etcd's own
+              write path, not host CPU/memory - a sustained miss here means
+              the disk backing etcd can't keep up, which is what drives the
+              request-timeout/NodeNotReady cascade tracked in issue #125.
+        - alert: EtcdHighBackendCommitDuration
+          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))) > 0.025
+          for: 10m
+          labels:
+            severity: warning
+          annotations:
+            summary: "etcd backend commit latency is above etcd's healthy-cluster guidance."
+            description: >-
+              {{ $labels.hostname }}'s etcd backend commit p99 has been
+              above 25ms for 10 minutes, is currently
+              {{ printf "%.1f" (mul $value 1000) }}ms. Same underlying
+              concern as EtcdHighFsyncDuration - see that alert's
+              description.

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -8,6 +8,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - namespace.yaml
+  - dashboards/etcd-overview.yaml
   - dashboards/flux-cluster.yaml
   - dashboards/jellyfin-process-health.yaml
   - dashboards/kubernetes-overview.yaml

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -100,6 +100,10 @@ data "talos_machine_configuration" "controlplane" {
             "metrics-bind-address" = "0.0.0.0:10249"
           }
         }
+        # On an already-running node, talosctl patch mc/apply-config alone
+        # persists this but doesn't bounce etcd - it refuses a plain
+        # service restart via the Talos API. A full node reboot is what
+        # actually picks up a change here.
         etcd = {
           extraArgs = {
             "listen-metrics-urls" = "http://0.0.0.0:2381"

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -100,10 +100,7 @@ data "talos_machine_configuration" "controlplane" {
             "metrics-bind-address" = "0.0.0.0:10249"
           }
         }
-        # On an already-running node, talosctl patch mc/apply-config alone
-        # persists this but doesn't bounce etcd - it refuses a plain
-        # service restart via the Talos API. A full node reboot is what
-        # actually picks up a change here.
+        # A full node reboot is required to apply changes to etcd.
         etcd = {
           extraArgs = {
             "listen-metrics-urls" = "http://0.0.0.0:2381"


### PR DESCRIPTION
Small doc-only follow-up to #148. The live rollout (patch mc + reboot on each of the three control planes) happened the same night, right after that PR merged - this just brings ADR 003's addendum up to date, since it still said "not yet run", and records the one real surprise: `talosctl apply-config`/`patch mc` in no-reboot mode persists the config but doesn't bounce etcd - Talos refuses a plain service restart for etcd via its API (`service "etcd" doesn't support restart operation via API`), so a full node reboot was actually required per node.

All three control planes confirmed `up` in Prometheus's `etcd` scrape job, `etcd_disk_wal_fsync_duration_seconds` actively incrementing on all three. Quorum stayed healthy the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)