### PR TITLE
Fix TrueNAS Disk I/O dashboard panel

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
@@ -310,10 +310,17 @@ data:
           "targets": [
             {
               "editorMode": "code",
-              "expr": "sum(rate(scale_truenas_truenas_disk_stats__devicename_sdg_writes[5m]))",
-              "legendFormat": "TrueNAS",
+              "expr": "sum({__name__=~\"scale_truenas_truenas_disk_stats__.*_reads\"})",
+              "legendFormat": "Reads",
               "range": true,
               "refId": "A"
+            },
+            {
+              "editorMode": "code",
+              "expr": "sum({__name__=~\"scale_truenas_truenas_disk_stats__.*_writes\"})",
+              "legendFormat": "Writes",
+              "range": true,
+              "refId": "B"
             }
           ],
           "title": "Disk I/O",


### PR DESCRIPTION
The Disk I/O panel on the TrueNAS Grafana dashboard was silently broken in two ways:

1. Hardcoded to `scale_truenas_truenas_disk_stats__devicename_sdg_writes` — that device name no longer exists; TrueNAS now reports disks under `serial_lunid_*` labels (and the boot-pool disk under `devicename_sdi`).
2. Wrapped the query in `rate()`, but these values are already TrueNAS-computed IOPS gauges, not counters. Once `rate()` strips the `__name__` label from a regex-matched multi-series selector, all series collapse to an identical (now-empty) labelset, which Prometheus rejects with `vector cannot contain metrics with the same labelset`.

Fixed by summing reads and writes separately across all currently-reported disks, with no `rate()` and no hardcoded device name — so it survives future disk renaming/renumbering. Verified live against Prometheus (both queries return real, non-error values) and confirmed Grafana's dashboard sidecar reloaded the panel without error.

Related: this surfaced while fixing the TrueNAS exporter/cron config that had gone missing on the TrueNAS host itself (separate issue, not part of this diff).