### PR TITLE
Raise sabnzbd memory limit to 5Gi

### DIFF
--- a/services/downloads-standard/sabnzbd/deployment.yaml
+++ b/services/downloads-standard/sabnzbd/deployment.yaml
@@ -41,7 +41,7 @@ spec:
             memory: "256Mi"
             cpu: "200m"
           limits:
-            memory: "2Gi"
+            memory: "5Gi"
             cpu: "2"
       volumes:
       - name: config


### PR DESCRIPTION
Container was OOMKilled (2Gi limit) while two large BluRay downloads (Spider-Man: Far From Home, Spider-Man: No Way Home) were unpacking/par2-verifying simultaneously. The crash lost in-flight queue admin state for a handful of files, causing `Error importing NzbFile` on restart (downloaded article data itself was intact).

Node running sabnzbd (k8s-razlo-w2) has ~11.4Gi allocatable and was at ~39% utilization, so a 5Gi limit fits comfortably. Only the limit changes — the 256Mi request is unchanged, so scheduling elsewhere is unaffected.