### PR TITLE
Add cluster-wide OOM alerting and memory-% dashboard column

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/kubernetes-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/kubernetes-overview.yaml
@@ -420,6 +420,60 @@ data:
               {
                 "matcher": {
                   "id": "byName",
+                  "options": "Memory Limit"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "bytes"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Memory %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-background"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "green",
+                          "value": 0
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.6
+                        },
+                        {
+                          "color": "red",
+                          "value": 0.8
+                        }
+                      ]
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
                   "options": "Restarts"
                 },
                 "properties": [
@@ -519,6 +573,18 @@ data:
               "instant": true,
               "range": false,
               "refId": "C"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "sum by (namespace, pod) (kube_pod_container_resource_limits{namespace!=\"\", container!=\"\", container!=\"POD\", resource=\"memory\"})",
+              "format": "table",
+              "instant": true,
+              "range": false,
+              "refId": "D"
             }
           ],
           "title": "Pod Resource Usage",
@@ -526,6 +592,19 @@ data:
             {
               "id": "merge",
               "options": {}
+            },
+            {
+              "id": "calculateField",
+              "options": {
+                "alias": "Memory %",
+                "binary": {
+                  "left": "Value #B",
+                  "operator": "/",
+                  "right": "Value #D"
+                },
+                "mode": "binary",
+                "replaceFields": false
+              }
             },
             {
               "id": "organize",
@@ -538,7 +617,8 @@ data:
                 "renameByName": {
                   "Value #A": "CPU (cores)",
                   "Value #B": "Memory",
-                  "Value #C": "Restarts"
+                  "Value #C": "Restarts",
+                  "Value #D": "Memory Limit"
                 }
               }
             }

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -10,13 +10,8 @@ spec:
     - name: custom-node-workload
       rules:
         - alert: NodeWorkloadMemoryHighUtilization
-          # Replaces the default NodeMemoryHighUtilization, which measures
-          # raw host MemAvailable - that tracks VM RAM *allocation* on this
-          # cluster (KVM reserves each VM's configured size whether or not
-          # it's actually used), not real memory pressure. This instead
-          # sums each host's VMs' actual guest-reported usage as a % of
-          # host capacity - same formula validated in proxmox-overview's
-          # "Workload RAM Used %" gauge.
+          # Replaces NodeMemoryHighUtilization, which measures raw MemAvailable
+          # (VM allocation, not real usage) - this sums actual guest RAM used.
           expr: |
             100 * sum by (host) (
               node_memory_MemTotal_bytes{job="node-exporter", role!="host"}
@@ -37,15 +32,10 @@ spec:
     - name: custom-jellyfin-process
       rules:
         # Jellyfin is hard-pinned to a single node (the only one with the
-        # passed-through iGPU) with no fallback - see services/jellyfin/
-        # values.yaml. These come from its own EnableMetrics endpoint
-        # (system_runtime_*/microsoft_aspnetcore_* series - .NET/ASP.NET
-        # Core process telemetry, not media-server activity), scraped via
-        # the `jellyfin` ServiceMonitor. See jellyfin-process-health
-        # Grafana dashboard for the panels these mirror.
+        # iGPU) with no fallback. Metrics come from its own EnableMetrics endpoint.
         - alert: JellyfinHighMemoryUsage
-          # Container limit is 4Gi (values.yaml resources.limits.memory).
-          # An OOMKill here takes down the only jellyfin instance outright.
+          # Container limit is 4Gi. An OOMKill here takes down the only
+          # jellyfin instance outright.
           expr: system_runtime_dotnet_process_memory_working_set{job="jellyfin"} > 3.5 * 1024 * 1024 * 1024
           for: 10m
           labels:
@@ -58,9 +48,8 @@ spec:
               {{ humanize1024 $value }}B. An OOMKill here
               takes down the only jellyfin instance - it has no fallback node.
         - alert: JellyfinThreadPoolQueueBacklog
-          # Work queuing up faster than the thread pool can drain it - an
-          # early, pre-crash signal of the process falling behind, usually
-          # visible as slow/stalled streams before anything else notices.
+          # Work queuing faster than it drains - an early, pre-crash signal,
+          # usually visible as slow/stalled streams before anything else notices.
           expr: system_runtime_threadpool_queue_length{job="jellyfin"} > 0
           for: 5m
           labels:
@@ -72,9 +61,8 @@ spec:
               minutes (currently {{ $value }}) - the process is falling
               behind on incoming work.
         - alert: JellyfinExceptionRateSpike
-          # Compares current exception rate to its own trailing 1h average
-          # rather than a fixed threshold, since some baseline exception
-          # noise from internal control flow is normal.
+          # Compares to its own trailing 1h average rather than a fixed
+          # threshold - some baseline exception noise is normal.
           expr: |
             rate(system_runtime_exception_count_total{job="jellyfin"}[5m]) > 0.05
             and
@@ -91,23 +79,16 @@ spec:
 
     - name: custom-container-memory
       rules:
-        # Cluster-wide OOM detection - kube-prometheus-stack's default rules
-        # only catch OOMs indirectly via KubePodCrashLooping, which needs
-        # several restarts in a short window. A single OOM+restart (like
-        # sabnzbd's on 2026-09-02, see services/downloads-standard/sabnzbd)
-        # doesn't trigger that. This fires on the restart itself, gated to
-        # only those actually caused by OOMKilled (not e.g. a crash or a
-        # manual `kubectl rollout restart`) by requiring the container's
-        # last-terminated reason to have been OOMKilled within the same
-        # window. `ignoring(reason)` is a no-op on the join (restarts_total
-        # doesn't carry a reason label) but is required for the `and` to
-        # match at all.
+        # Cluster-wide OOM detection - default rules only catch this via
+        # crash-looping (several restarts); this fires on a single OOM+restart.
         - alert: ContainerOOMKilled
           expr: |
             (
               kube_pod_container_status_restarts_total
               - (kube_pod_container_status_restarts_total offset 15m) >= 1
             )
+            # ignoring(reason) is a no-op here (restarts_total has no reason
+            # label) but is required for the `and` join to match at all.
             and ignoring(reason) (
               max_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[15m]) == 1
             )
@@ -121,15 +102,10 @@ spec:
               was restarted after being OOMKilled in the last 15 minutes.
               Check whether its memory limit needs raising.
         # Early warning ahead of ContainerOOMKilled - catches a container
-        # climbing toward its limit before it actually gets killed, same
-        # idea as JellyfinHighMemoryUsage above but generalized to every
-        # container with a memory limit set (pods with no limit are excluded
-        # by the join, not scored as 0%).
+        # climbing toward its limit before it's actually killed.
         - alert: ContainerMemoryNearLimit
-          # Scaled to a percentage in the expr itself (not the description
-          # template) - Prometheus's annotation templates don't have a "mul"
-          # function; see EtcdHighFsyncDuration's note below, which had the
-          # same bug.
+          # Scaled to % in the expr, not the description - Prometheus's
+          # templates have no "mul" func; see EtcdHighFsyncDuration below.
           expr: |
             100 * sum by (namespace, pod, container) (container_memory_working_set_bytes{container!="", container!="POD"})
             / on (namespace, pod, container) group_left
@@ -148,25 +124,11 @@ spec:
 
     - name: custom-etcd-latency
       rules:
-        # Scraped via the etcd job added alongside docs/adr/003-control-
-        # plane-metrics-exposure.md's etcd addendum - see etcd-overview
-        # Grafana dashboard for the panels these mirror. Thresholds (10ms
-        # fsync p99, 25ms backend commit p99) are etcd's own documented
-        # healthy-cluster guidance, not values tuned to this cluster.
+        # Scraped via the etcd job in ADR 003's etcd addendum - see
+        # etcd-overview dashboard. Thresholds are etcd's own healthy-cluster guidance.
         #
-        # Built investigating issue #125 (recurring etcd-overload/NotReady
-        # flapping, one recurrence causing a live Jellyfin stutter) - host-
-        # level proxies (disk busy%, CPU steal) stayed flat through that
-        # incident, so these are the metrics that would have actually shown
-        # whether it was real disk latency.
-        #
-        # Both thresholds are expressed in ms directly in the expr (not
-        # left as seconds and converted for display) - Prometheus's
-        # annotation templates don't have a "mul" function, so a `(mul
-        # $value 1000)` in the description silently fails PrometheusRule's
-        # admission webhook. That's exactly what had these two rules (and
-        # this whole file) failing Flux reconciliation since they were
-        # added - see git blame.
+        # Scaled to ms in the expr, not the description - a `mul $value 1000`
+        # there previously failed admission (no "mul" func) and Flux reconciliation.
         - alert: EtcdHighFsyncDuration
           expr: 1000 * histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 10
           for: 10m

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -89,6 +89,63 @@ spec:
               Jellyfin is throwing exceptions at {{ printf "%.2f" $value }}/s,
               more than 3x its trailing 1-hour average, for 5 minutes.
 
+    - name: custom-container-memory
+      rules:
+        # Cluster-wide OOM detection - kube-prometheus-stack's default rules
+        # only catch OOMs indirectly via KubePodCrashLooping, which needs
+        # several restarts in a short window. A single OOM+restart (like
+        # sabnzbd's on 2026-09-02, see services/downloads-standard/sabnzbd)
+        # doesn't trigger that. This fires on the restart itself, gated to
+        # only those actually caused by OOMKilled (not e.g. a crash or a
+        # manual `kubectl rollout restart`) by requiring the container's
+        # last-terminated reason to have been OOMKilled within the same
+        # window. `ignoring(reason)` is a no-op on the join (restarts_total
+        # doesn't carry a reason label) but is required for the `and` to
+        # match at all.
+        - alert: ContainerOOMKilled
+          expr: |
+            (
+              kube_pod_container_status_restarts_total
+              - (kube_pod_container_status_restarts_total offset 15m) >= 1
+            )
+            and ignoring(reason) (
+              max_over_time(kube_pod_container_status_last_terminated_reason{reason="OOMKilled"}[15m]) == 1
+            )
+          for: 0m
+          labels:
+            severity: warning
+          annotations:
+            summary: "A container was OOMKilled."
+            description: >-
+              {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})
+              was restarted after being OOMKilled in the last 15 minutes.
+              Check whether its memory limit needs raising.
+        # Early warning ahead of ContainerOOMKilled - catches a container
+        # climbing toward its limit before it actually gets killed, same
+        # idea as JellyfinHighMemoryUsage above but generalized to every
+        # container with a memory limit set (pods with no limit are excluded
+        # by the join, not scored as 0%).
+        - alert: ContainerMemoryNearLimit
+          # Scaled to a percentage in the expr itself (not the description
+          # template) - Prometheus's annotation templates don't have a "mul"
+          # function; see EtcdHighFsyncDuration's note below, which had the
+          # same bug.
+          expr: |
+            100 * sum by (namespace, pod, container) (container_memory_working_set_bytes{container!="", container!="POD"})
+            / on (namespace, pod, container) group_left
+            sum by (namespace, pod, container) (kube_pod_container_resource_limits{resource="memory"})
+            > 85
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "A container's memory usage is approaching its limit."
+            description: >-
+              {{ $labels.namespace }}/{{ $labels.pod }} ({{ $labels.container }})
+              has used more than 85% of its memory limit for 15 minutes,
+              currently {{ printf "%.1f" $value }}%. Risks an OOMKill if it
+              keeps climbing.
+
     - name: custom-etcd-latency
       rules:
         # Scraped via the etcd job added alongside docs/adr/003-control-
@@ -102,8 +159,16 @@ spec:
         # level proxies (disk busy%, CPU steal) stayed flat through that
         # incident, so these are the metrics that would have actually shown
         # whether it was real disk latency.
+        #
+        # Both thresholds are expressed in ms directly in the expr (not
+        # left as seconds and converted for display) - Prometheus's
+        # annotation templates don't have a "mul" function, so a `(mul
+        # $value 1000)` in the description silently fails PrometheusRule's
+        # admission webhook. That's exactly what had these two rules (and
+        # this whole file) failing Flux reconciliation since they were
+        # added - see git blame.
         - alert: EtcdHighFsyncDuration
-          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 0.01
+          expr: 1000 * histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 10
           for: 10m
           labels:
             severity: warning
@@ -112,12 +177,12 @@ spec:
             description: >-
               {{ $labels.hostname }}'s etcd WAL fsync p99 has been above
               10ms for 10 minutes, is currently
-              {{ printf "%.1f" (mul $value 1000) }}ms. This is etcd's own
+              {{ printf "%.1f" $value }}ms. This is etcd's own
               write path, not host CPU/memory - a sustained miss here means
               the disk backing etcd can't keep up, which is what drives the
               request-timeout/NodeNotReady cascade tracked in issue #125.
         - alert: EtcdHighBackendCommitDuration
-          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))) > 0.025
+          expr: 1000 * histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))) > 25
           for: 10m
           labels:
             severity: warning
@@ -126,6 +191,6 @@ spec:
             description: >-
               {{ $labels.hostname }}'s etcd backend commit p99 has been
               above 25ms for 10 minutes, is currently
-              {{ printf "%.1f" (mul $value 1000) }}ms. Same underlying
+              {{ printf "%.1f" $value }}ms. Same underlying
               concern as EtcdHighFsyncDuration - see that alert's
               description.


### PR DESCRIPTION
Prompted by sabnzbd's OOMKill this week — kube-prometheus-stack's default rules only catch OOMs indirectly via crash-loop detection (needs several restarts in a short window), which wouldn't have fired for a single OOM+restart like sabnzbd's.

### New alerts

Added to `custom-alerts.yaml` under a new `custom-container-memory` group, cluster-wide across every namespace/pod:

- **ContainerOOMKilled** — fires on the restart itself, gated to only restarts actually caused by OOMKilled (not crashes or manual restarts).
- **ContainerMemoryNearLimit** — advance warning when a container has held over 85% of its memory limit for 15 minutes, before it actually gets OOMKilled.

### Dashboard

The "Pod Resource Usage" table on `kubernetes-overview` now has a Memory Limit column and a color-coded Memory % column (green, yellow at 60%, red at 80%).

### Bonus fix

While testing this live, found the existing etcd-latency alerts have been broken since they were added (`a453ff9`): they used `(mul $value 1000)` in their description templates, but `mul` isn't a real Prometheus/Alertmanager template function. PrometheusRule's admission webhook has been rejecting the whole file ever since, which has been failing the `observability` Flux Kustomization's reconciliation this whole time. Reworked both alerts to scale the value in the PromQL expression instead, so the description just prints `$value` directly.

### Verification

Applied directly to the live cluster and checked before committing:
- Both new alert expressions and the dashboard's memory-% calculation return correct data against live Prometheus.
- All 4 rules (2 new + 2 fixed etcd ones) load in Prometheus with no eval errors.
- Grafana's dashboard sidecar picked up the updated ConfigMap.