### PR TITLE
Fix invalid mul template function in etcd alert annotations

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -103,7 +103,7 @@ spec:
         # incident, so these are the metrics that would have actually shown
         # whether it was real disk latency.
         - alert: EtcdHighFsyncDuration
-          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 0.01
+          expr: 1000 * histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_wal_fsync_duration_seconds_bucket{job="etcd"}[5m]))) > 10
           for: 10m
           labels:
             severity: warning
@@ -112,12 +112,12 @@ spec:
             description: >-
               {{ $labels.hostname }}'s etcd WAL fsync p99 has been above
               10ms for 10 minutes, is currently
-              {{ printf "%.1f" (mul $value 1000) }}ms. This is etcd's own
+              {{ printf "%.1f" $value }}ms. This is etcd's own
               write path, not host CPU/memory - a sustained miss here means
               the disk backing etcd can't keep up, which is what drives the
               request-timeout/NodeNotReady cascade tracked in issue #125.
         - alert: EtcdHighBackendCommitDuration
-          expr: histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))) > 0.025
+          expr: 1000 * histogram_quantile(0.99, sum by (le, hostname) (rate(etcd_disk_backend_commit_duration_seconds_bucket{job="etcd"}[5m]))) > 25
           for: 10m
           labels:
             severity: warning
@@ -126,6 +126,6 @@ spec:
             description: >-
               {{ $labels.hostname }}'s etcd backend commit p99 has been
               above 25ms for 10 minutes, is currently
-              {{ printf "%.1f" (mul $value 1000) }}ms. Same underlying
+              {{ printf "%.1f" $value }}ms. Same underlying
               concern as EtcdHighFsyncDuration - see that alert's
               description.


### PR DESCRIPTION
The `custom-node-alerts` PrometheusRule has been failing admission validation for 8+ days, blocking the `observability` Flux Kustomization from reconciling:

```
PrometheusRule/observability/custom-node-alerts dry-run failed (Invalid): admission webhook "prometheusrulevalidate.monitoring.coreos.com" denied the request: Rules are not valid
```

Root cause: `EtcdHighFsyncDuration` and `EtcdHighBackendCommitDuration`'s description annotations called a `mul` template function, which isn't part of Prometheus's [template reference](https://prometheus.io/docs/prometheus/latest/configuration/template_reference/) — it doesn't exist, so the whole rule failed to validate.

Fix: do the ×1000 (seconds → ms) conversion in the PromQL expression itself instead of the Go template, so the threshold and `$value` are already in milliseconds by the time the annotation renders them.

Verified live: applied to the cluster, confirmed via Prometheus's `/api/v1/rules` that both alerts now load without error and render their descriptions correctly (e.g. "...is currently 63.9ms").

Note: live-verifying this surfaced that both alerts are actually firing right now across all three control planes — that's a separate, real issue and is being tracked in its own ticket rather than folded into this fix.