### PR TITLE
docs(talos): stop baking i915 into the VM template

### DIFF
--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -5,13 +5,15 @@ Preparing the Talos Linux disk image for Kubernetes node deployment.
 ## Overview
 Talos is an immutable OS, meaning it is read-only and cannot be modified after deployment. Configuration is managed via a declarative YAML file that is applied at boot time.
 
-Every node runs the `qemu-guest-agent` and `i915` system extensions (see `infrastructure/proxmox/opentofu/cluster.tf` / `locals.tf`). `i915` (Intel GPU driver) is universal across all workers even though only one node (`k8s-livio-w1`) actually has a GPU passed through - see `services/jellyfin/README.md` and the GPU passthrough section below for why. The extension set has to be baked into the **template** image (see Step 1) - adding an extension to `install.extensions` in Terraform's machine config does **not** retroactively apply to an already-installed node or to a fresh clone of an existing template. It only takes effect via a genuine reinstall: either `talosctl upgrade` against an already-running node, or (what we do here) rebuilding the template and destroying/recreating the VM so it clones fresh.
+`infrastructure/proxmox/opentofu/cluster.tf` resolves each role's extension set (`qemu-guest-agent` for control planes, `qemu-guest-agent` + `i915` for workers - see `locals.tf`) into a Talos Image Factory schematic and feeds it into `machine.install.image`. Talos reinstalls itself to that image on first boot regardless of what the template already had, so `install.image` is the sole source of truth for which extensions actually end up running - `i915` (Intel GPU driver, universal across workers even though only `k8s-livio-w1` has a GPU passed through - see `services/jellyfin/README.md` and the GPU passthrough section below) never needs to be baked into the template itself.
+
+The **template** (see Step 1) only bakes in `qemu-guest-agent`, and only for one reason: Terraform's `agent { enabled = true }` block (`vms.tf`) waits for the QEMU guest agent to respond before considering a clone "up". Since the currently-booted image keeps running (and the agent with it) throughout Talos's background reinstall to `install.image`, having the agent present from the template means that wait never stalls, no matter what `install.image` ends up changing. If the extension set in `cluster.tf` ever changes, that takes effect for every fleet node the next time it goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against a current template) - no template rebuild required.
 
 ## Steps
 ### Step 1: Get Talos Linux Image
 Run these steps on **each** proxmox host
 
-1. Get the schematic ID for the extension set we want (`qemu-guest-agent` + `i915`) from the Image Factory:
+1. Get the schematic ID for the template's extension set - just `qemu-guest-agent`, so Terraform's `agent { enabled = true }` wait has something to talk to immediately on first boot. Everything role-specific (like `i915`) is applied later via `cluster.tf`'s `install.image`, not baked in here:
 ```bash
 curl -s -X POST https://factory.talos.dev/schematics \
   -H "Content-Type: application/json" \
@@ -19,14 +21,13 @@ curl -s -X POST https://factory.talos.dev/schematics \
     "customization": {
       "systemExtensions": {
         "officialExtensions": [
-          "siderolabs/qemu-guest-agent",
-          "siderolabs/i915"
+          "siderolabs/qemu-guest-agent"
         ]
       }
     }
   }'
 ```
-This returns a schematic `id` (a stable hash of the extension list - independent of Talos version). As of the `livio` rebuild this was `d3dc673627e9b94c6cd4122289aa52c2484cddb31017ae21b75309846e257d30`. Re-run this if the extension list ever changes; the id will change too.
+This returns a schematic `id` (a stable hash of the extension list - independent of Talos version). Re-run this if the template's own extension set ever changes; the id will change too.
 
 2. Download the image (`nocloud`, not `bare-metal`, because it includes cloud-init support which Talos uses for initial configuration - `raw.xz` format):
 ```bash

--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -5,15 +5,27 @@ Preparing the Talos Linux disk image for Kubernetes node deployment.
 ## Overview
 Talos is an immutable OS, meaning it is read-only and cannot be modified after deployment. Configuration is managed via a declarative YAML file that is applied at boot time.
 
-`infrastructure/proxmox/opentofu/cluster.tf` resolves each role's extension set (`qemu-guest-agent` for control planes, `qemu-guest-agent` + `i915` for workers - see `locals.tf`) into a Talos Image Factory schematic and feeds it into `machine.install.image`. Talos reinstalls itself to that image on first boot regardless of what the template already had, so `install.image` is the sole source of truth for which extensions actually end up running - `i915` (Intel GPU driver, universal across workers even though only `k8s-livio-w1` has a GPU passed through - see `services/jellyfin/README.md` and the GPU passthrough section below) never needs to be baked into the template itself.
+### Who owns which extensions
 
-The **template** (see Step 1) only bakes in `qemu-guest-agent`, and only for one reason: Terraform's `agent { enabled = true }` block (`vms.tf`) waits for the QEMU guest agent to respond before considering a clone "up". Since the currently-booted image keeps running (and the agent with it) throughout Talos's background reinstall to `install.image`, having the agent present from the template means that wait never stalls, no matter what `install.image` ends up changing. If the extension set in `cluster.tf` ever changes, that takes effect for every fleet node the next time it goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against a current template) - no template rebuild required.
+`infrastructure/proxmox/opentofu/cluster.tf` resolves each role's extension set into a Talos Image Factory schematic and feeds it into `machine.install.image`:
+- Control planes: `qemu-guest-agent`
+- Workers: `qemu-guest-agent` + `i915` (see `locals.tf`)
+
+`i915` is the Intel GPU driver - it's universal across all workers even though only `k8s-livio-w1` actually has a GPU passed through (see `services/jellyfin/README.md` and the GPU passthrough section below).
+
+Talos reinstalls itself to `install.image` on first boot **regardless of what the template already had**, so `install.image`/`cluster.tf` is the sole source of truth for which extensions actually end up running. That means `i915` never needs to be baked into the template itself - only `cluster.tf` needs to know about it.
+
+The **template** (Step 1 below) bakes in only `qemu-guest-agent`, and for one specific reason:
+- Terraform's `agent { enabled = true }` block (`vms.tf`) waits for the QEMU guest agent to respond before it considers a clone "up".
+- The currently-booted image (and its agent) keeps running throughout Talos's background reinstall to `install.image` - so having the agent present from the template means that wait never stalls, whatever `install.image` changes to.
+
+If the extension set in `cluster.tf` ever changes, that takes effect fleet-wide the next time each node goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against the current template) - **no template rebuild required**.
 
 ## Steps
 ### Step 1: Get Talos Linux Image
 Run these steps on **each** proxmox host
 
-1. Get the schematic ID for the template's extension set - just `qemu-guest-agent`, so Terraform's `agent { enabled = true }` wait has something to talk to immediately on first boot. Everything role-specific (like `i915`) is applied later via `cluster.tf`'s `install.image`, not baked in here:
+1. Get the schematic ID for the template's extension set. The template only needs `qemu-guest-agent` (see "Who owns which extensions" above) - everything role-specific like `i915` is applied later via `cluster.tf`'s `install.image`, not baked in here:
 ```bash
 curl -s -X POST https://factory.talos.dev/schematics \
   -H "Content-Type: application/json" \


### PR DESCRIPTION
## Why

`cluster.tf` already resolves each role's extension set (`qemu-guest-agent` for control planes, `qemu-guest-agent` + `i915` for workers) into a Talos Image Factory schematic fed into `machine.install.image`, and Talos reinstalls to that image on first boot regardless of what the template already had. Baking `i915` into the template as well (per the old `talos.md` Step 1) was redundant - it never saved a step, since the reinstall happens anyway.

## What changed

Docs only - `docs/bootstrap/talos.md`:
- Added a "Who owns which extensions" subsection explaining that `install.image`/`cluster.tf` is the sole source of truth for extensions, and that the template only needs `qemu-guest-agent` (kept specifically so Terraform's `agent { enabled = true }` wait in `vms.tf` never stalls, since the agent survives Talos's background reinstall).
- Step 1's schematic request now asks for `qemu-guest-agent` only, dropping `i915`.

No `cluster.tf`/`vms.tf` changes: `cluster.tf` already resolves extensions per-role independently, and `vms.tf`'s agent-wait keeps working as-is once `qemu-guest-agent` stays in the template - the dependency rework originally scoped in #16 turned out to be unnecessary.

## Related

Addresses the documentation portion of #16. Not closing it: the issue's testing checklist (rebuild a template on a throwaway host, confirm `tofu apply` doesn't stall, confirm `i915` lands via `install.image` post-reinstall, then destroy the scratch VM) still needs to happen the next time a template is actually rebuilt.