### PR TITLE
Remove kube-linter's PR comment

### DIFF
--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -148,14 +148,15 @@ jobs:
           exit "$exit_code"
 
       # Only posts on failure - the check's own pass/fail status is already
-      # visible in the merge panel. delete clears a stale failure comment
-      # from an earlier run once the PR is fixed.
+      # visible in the merge panel. No delete-on-pass: recreating a deleted
+      # comment on a later failure emails a "new comment" notification,
+      # where editing an existing one doesn't - a stale comment can outlive
+      # a fix, but it won't generate a repeat email.
       - name: Comment findings on PR
-        if: always() && steps.lint.outputs.files_changed == 'true'
+        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code != '0'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: kube-linter
-          delete: ${{ steps.lint.outputs.exit_code == '0' }}
           message: |
             ### kube-linter ❌ failed
 

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -148,12 +148,12 @@ jobs:
           exit "$exit_code"
 
       - name: Comment findings on PR
-        if: always() && steps.lint.outputs.files_changed == 'true'
+        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code != '0'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: kube-linter
           message: |
-            ### kube-linter ${{ steps.lint.outputs.exit_code == '0' && '✅ passed' || '❌ failed' }}
+            ### kube-linter ❌ failed
 
             Checked against the Kubernetes manifests changed in this PR.
             Required check - `.kube-linter.yaml` currently enables checks
@@ -168,3 +168,12 @@ jobs:
             ```
 
             </details>
+
+      # Clears a stale failure comment from an earlier run once the PR is fixed -
+      # the check's own pass/fail status is already visible in the merge panel.
+      - name: Remove stale comment on pass
+        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code == '0'
+        uses: marocchino/sticky-pull-request-comment@v3
+        with:
+          header: kube-linter
+          delete: true

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -134,25 +134,11 @@ jobs:
           exit_code=$?
           set -e
 
-          echo "$output"
-
           # No PR comment - the check's own pass/fail status is already
           # visible in the merge panel, and a comment on every run either
           # emails on each failure or risks re-notifying on deletion once
-          # fixed. The output above and this summary are the record.
-          if [ "$exit_code" -ne 0 ]; then
-            {
-              echo '### kube-linter ❌ failed'
-              echo
-              echo 'Checked against the Kubernetes manifests changed in this PR.'
-              echo 'Required check - `.kube-linter.yaml` currently enables checks'
-              echo 'one at a time as the fleet is brought into compliance with each'
-              echo '(see #115); it cannot yet fail on anything that is not listed there.'
-              echo
-              echo '```'
-              echo "$output"
-              echo '```'
-            } >> "$GITHUB_STEP_SUMMARY"
-          fi
+          # fixed. This log output is the record - see the failing check's
+          # details for findings.
+          echo "$output"
 
           exit "$exit_code"

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -147,11 +147,15 @@ jobs:
 
           exit "$exit_code"
 
+      # Only posts on failure - the check's own pass/fail status is already
+      # visible in the merge panel. delete clears a stale failure comment
+      # from an earlier run once the PR is fixed.
       - name: Comment findings on PR
-        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code != '0'
+        if: always() && steps.lint.outputs.files_changed == 'true'
         uses: marocchino/sticky-pull-request-comment@v3
         with:
           header: kube-linter
+          delete: ${{ steps.lint.outputs.exit_code == '0' }}
           message: |
             ### kube-linter ❌ failed
 
@@ -168,12 +172,3 @@ jobs:
             ```
 
             </details>
-
-      # Clears a stale failure comment from an earlier run once the PR is fixed -
-      # the check's own pass/fail status is already visible in the merge panel.
-      - name: Remove stale comment on pass
-        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code == '0'
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: kube-linter
-          delete: true

--- a/.github/workflows/pr-validate.yml
+++ b/.github/workflows/pr-validate.yml
@@ -85,7 +85,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v7
         with:
@@ -103,7 +102,6 @@ jobs:
           sudo install kube-linter /usr/local/bin/kube-linter
 
       - name: kube-linter
-        id: lint
         run: |
           set -e
           # If the ruleset itself changed, a diff-scoped run wouldn't catch
@@ -125,7 +123,6 @@ jobs:
               ':(exclude)*values.yaml' ':(exclude)*values.yml')
           fi
 
-          echo "files_changed=$([ "${#files[@]}" -gt 0 ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
           if [ "${#files[@]}" -eq 0 ]; then
             echo "No Kubernetes manifests changed - skipping"
             exit 0
@@ -138,38 +135,24 @@ jobs:
           set -e
 
           echo "$output"
-          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
-          {
-            echo "report<<KUBE_LINTER_EOF"
-            echo "$output"
-            echo "KUBE_LINTER_EOF"
-          } >> "$GITHUB_OUTPUT"
+
+          # No PR comment - the check's own pass/fail status is already
+          # visible in the merge panel, and a comment on every run either
+          # emails on each failure or risks re-notifying on deletion once
+          # fixed. The output above and this summary are the record.
+          if [ "$exit_code" -ne 0 ]; then
+            {
+              echo '### kube-linter ❌ failed'
+              echo
+              echo 'Checked against the Kubernetes manifests changed in this PR.'
+              echo 'Required check - `.kube-linter.yaml` currently enables checks'
+              echo 'one at a time as the fleet is brought into compliance with each'
+              echo '(see #115); it cannot yet fail on anything that is not listed there.'
+              echo
+              echo '```'
+              echo "$output"
+              echo '```'
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
           exit "$exit_code"
-
-      # Only posts on failure - the check's own pass/fail status is already
-      # visible in the merge panel. No delete-on-pass: recreating a deleted
-      # comment on a later failure emails a "new comment" notification,
-      # where editing an existing one doesn't - a stale comment can outlive
-      # a fix, but it won't generate a repeat email.
-      - name: Comment findings on PR
-        if: always() && steps.lint.outputs.files_changed == 'true' && steps.lint.outputs.exit_code != '0'
-        uses: marocchino/sticky-pull-request-comment@v3
-        with:
-          header: kube-linter
-          message: |
-            ### kube-linter ❌ failed
-
-            Checked against the Kubernetes manifests changed in this PR.
-            Required check - `.kube-linter.yaml` currently enables checks
-            one at a time as the fleet is brought into compliance with each
-            (see [#115](../../issues/115)); it can't yet fail on anything
-            that isn't listed there.
-
-            <details><summary>kube-linter output</summary>
-
-            ```
-            ${{ steps.lint.outputs.report }}
-            ```
-
-            </details>


### PR DESCRIPTION
The merge panel already shows kube-linter's pass/fail status as the required check, so a PR comment restating it is redundant. It's also a source of email noise: any comment — even one edited in place on later runs — emails once on creation, and a delete/recreate cycle (from flapping between pass/fail across pushes) would email every time.

This drops the sticky PR comment entirely. Failure detail (the full kube-linter output) now goes to the job's step summary, visible on the Checks tab, instead of the PR conversation. Also drops the now-unused `pull-requests: write` permission on the job.