### PR TITLE
Cap lscr.io concurrent requests to fix Renovate 429s

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -59,6 +59,13 @@
       "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
+  "hostRules": [
+    {
+      "description": "lscr.io (linuxserver's registry, proxied through GitHub's infra) 429'd every *arr-stack lookup in a single run because Renovate fired them concurrently and burst past its short-window limit, even though the advertised rate (44000/minute) is generous. Capping concurrency here spaces the requests out instead.",
+      "matchHost": "lscr.io",
+      "concurrentRequestLimit": 1
+    }
+  ],
   "packageRules": [
     {
       "description": "Group the *arr media stack together so a bump lands as one PR instead of one per app",


### PR DESCRIPTION
## Why

The Dependency Dashboard (#3) was reporting a repo-level warning ("Invalid
registry response") plus five failed lookups, all for `lscr.io/linuxserver/*`
images (`bazarr`, `prowlarr`, `radarr`, `sabnzbd`, `sonarr`). The Renovate
cronjob logs show the real cause: `lscr.io` (proxied through GitHub's infra)
returned `429 TOOMANYREQUESTS` because Renovate fired all five lookups for
the *arr stack concurrently in the same run and burst past a short-window
limit, even though the advertised rate (44000/minute) is generous.

## What

Add a `hostRules` entry capping `lscr.io` to one concurrent request, so
Renovate spaces the lookups out instead of bursting them. This is the
standard Renovate mitigation for registries that rate-limit bursts rather
than sustained volume.

## Verification

Next scheduled Renovate run (nightly, 06:00 UTC) should resolve the five
*arr-stack images without a 429. Will confirm the Dependency Dashboard
clears the warning and failed-lookup section after that run.