### PR TITLE
Disable CHAP - unsupported by democratic-csi's Linux node driver

### DIFF
--- a/infrastructure/kubernetes/storage/democratic-csi/helmrelease.yaml
+++ b/infrastructure/kubernetes/storage/democratic-csi/helmrelease.yaml
@@ -51,8 +51,8 @@ spec:
           targetGroups:
             - targetGroupPortalGroup: 1
               targetGroupInitiatorGroup: 1
-              targetGroupAuthType: CHAP
-              targetGroupAuthGroup: 1
+              # CHAP unsupported. See issue #172.
+              targetGroupAuthType: None
           extentInsecureTpc: true
           extentXenCompat: false
           extentDisablePhysicalBlocksize: true


### PR DESCRIPTION
Follow-up to #173-#177. First real mount attempt (step 7's validation) hung indefinitely:

```
iscsiadm -m node -T iqn... -p 10.0.10.20:3260 -l
```

never returned (confirmed via `talosctl processes` - the process was genuinely still running, not just slow), and every retry failed with `operation locked due to in progress operation(s)` since the driver's internal lock for that volume was held by the stuck first attempt.

**Root cause, confirmed by reading upstream source** (not guessed): CHAP credential handling (`chap_username`/`chap_secret` from `node-db.node.session.auth.*`) exists **only** in `src/driver/index.js`'s Windows csi-proxy code path. The Linux `iscsiadm`-based path has zero equivalent code - there's nowhere for the driver to even pass CHAP credentials to `iscsiadm` before login on Linux. A login attempt against a CHAP-required target just hangs instead of failing.

Disabling CHAP (`targetGroupAuthType: None`) - not a config oversight, this driver genuinely can't do CHAP on Linux today. Initiator group is already scoped to the trusted internal subnet (allow-all, NAT-bounded), so this isn't a new exposure. Noted as a known gap on #172 for anyone considering CHAP again later.