### PR TITLE
Deploy cross-seed (search-mode, direct client injection)

### DIFF
--- a/services/downloads-standard/cross-seed/README.md
+++ b/services/downloads-standard/cross-seed/README.md
@@ -1,0 +1,44 @@
+# cross-seed
+
+Matches torrents already seeding in qBittorrent against other indexers
+(via Prowlarr) and injects the match directly into qBittorrent, so
+existing data earns ratio on additional trackers without re-downloading.
+
+Runs in daemon mode: a 30-minute RSS cadence catches new torznab entries
+quickly, plus a slower full-catalog search pass (`searchCadence: 1 day`)
+to backfill matches for everything already seeding.
+
+Not exposed via Ingress - it's only reached in-cluster today. Once
+autobrr is deployed (#182), autobrr's announce webhook will call
+cross-seed's HTTP API directly for near-instant matching, instead of
+relying on the daily search pass.
+
+## Secrets
+
+Before applying the manifests, create `cross-seed-secrets`:
+
+```sh
+kubectl create secret generic cross-seed-secrets \
+  --namespace downloads-standard \
+  --from-literal=prowlarr-api-key='<Prowlarr API key, from Settings > General>' \
+  --from-literal=qbittorrent-username='<qBittorrent WebUI username>' \
+  --from-literal=qbittorrent-password='<qBittorrent WebUI password>' \
+  --from-literal=cross-seed-api-key='<any random string - authenticates calls to cross-seed's own API>'
+```
+
+If qBittorrent's WebUI has no password set (local-subnet auth bypass),
+leave `qbittorrent-username`/`qbittorrent-password` as empty strings
+rather than omitting the keys - `config.js` always references both.
+
+## Verifying
+
+```sh
+kubectl logs -n downloads-standard -l app=cross-seed -f
+```
+
+A manual full-catalog search can be triggered without waiting for
+`searchCadence`:
+
+```sh
+kubectl exec -n downloads-standard deploy/cross-seed -- cross-seed search
+```

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -1,0 +1,30 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cross-seed-config
+  namespace: downloads-standard
+data:
+  config.js: |
+    module.exports = {
+      torznab: [
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/1/api?apikey=${process.env.PROWLARR_API_KEY}`,
+      ],
+      torrentClients: [
+        `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,
+      ],
+      // Matches qBittorrent's own /media mount, so a match's save path lines
+      // up with qBittorrent's and cross-seed can inject directly into the
+      // client instead of needing separate linkDirs.
+      dataDirs: ["/media"],
+      matchMode: "safe",
+      action: "inject",
+      linkCategory: "cross-seed",
+      duplicateCategories: false,
+      rssCadence: "30 minutes",
+      searchCadence: "1 day",
+      excludeRecentSearch: "3 days",
+      delay: 30,
+      apiKey: process.env.CROSS_SEED_API_KEY,
+      port: 2468,
+      host: "0.0.0.0",
+    };

--- a/services/downloads-standard/cross-seed/deployment.yaml
+++ b/services/downloads-standard/cross-seed/deployment.yaml
@@ -1,0 +1,82 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cross-seed
+  namespace: downloads-standard
+spec:
+  replicas: 1
+  # RollingUpdate would briefly run two pods against cross-seed-config at
+  # once. nfs-provisioner doesn't enforce ReadWriteOnce exclusivity, so
+  # concurrent writers from two nodes can corrupt state on this PVC.
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app: cross-seed
+  template:
+    metadata:
+      labels:
+        app: cross-seed
+    spec:
+      # cross-seed has no PUID/PGID support - it runs as whatever UID the
+      # container is given, which must match qBittorrent's (1000) so files
+      # it links/injects against on the shared media PVC are writable.
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+      containers:
+      - name: cross-seed
+        image: ghcr.io/cross-seed/cross-seed:6.13.7
+        args: ["daemon"]
+        ports:
+        - containerPort: 2468
+          name: http
+        env:
+        - name: TZ
+          value: "America/New_York"
+        - name: PROWLARR_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: cross-seed-secrets
+              key: prowlarr-api-key
+        - name: QBITTORRENT_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: cross-seed-secrets
+              key: qbittorrent-username
+        - name: QBITTORRENT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: cross-seed-secrets
+              key: qbittorrent-password
+        - name: CROSS_SEED_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: cross-seed-secrets
+              key: cross-seed-api-key
+        volumeMounts:
+        - name: config
+          mountPath: /config
+        - name: config-js
+          mountPath: /config/config.js
+          subPath: config.js
+        - name: media
+          mountPath: /media
+          readOnly: true
+        resources:
+          requests:
+            memory: "128Mi"
+            cpu: "100m"
+          limits:
+            memory: "512Mi"
+            cpu: "500m"
+      volumes:
+      - name: config
+        persistentVolumeClaim:
+          claimName: cross-seed-config
+      - name: config-js
+        configMap:
+          name: cross-seed-config
+      - name: media
+        persistentVolumeClaim:
+          claimName: media-standard

--- a/services/downloads-standard/cross-seed/deployment.yaml
+++ b/services/downloads-standard/cross-seed/deployment.yaml
@@ -5,9 +5,11 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
-  # RollingUpdate would briefly run two pods against cross-seed-config at
-  # once. nfs-provisioner doesn't enforce ReadWriteOnce exclusivity, so
-  # concurrent writers from two nodes can corrupt state on this PVC.
+  # cross-seed-config is on truenas-iscsi, a true single-attach RWO volume:
+  # RollingUpdate would try to bring up the new pod before tearing down the
+  # old one, and the new pod's attach would block on the old pod's node still
+  # holding the volume - a stuck rollout (Multi-Attach error), not silent
+  # corruption like on NFS, but still needs Recreate to avoid.
   strategy:
     type: Recreate
   selector:

--- a/services/downloads-standard/cross-seed/pvc.yaml
+++ b/services/downloads-standard/cross-seed/pvc.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  storageClassName: nfs-provisioner
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 2Gi

--- a/services/downloads-standard/cross-seed/pvc.yaml
+++ b/services/downloads-standard/cross-seed/pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: cross-seed-config
+  namespace: downloads-standard
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-provisioner
+  resources:
+    requests:
+      storage: 2Gi

--- a/services/downloads-standard/cross-seed/secret.yaml
+++ b/services/downloads-standard/cross-seed/secret.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cross-seed-secrets
+  namespace: downloads-standard
+# Populated out of band via kubectl (see README) rather than committed:
+# Prowlarr API key, qBittorrent WebUI credentials, and cross-seed's own
+# daemon API key (used to authenticate webhook/search-trigger calls, e.g.
+# from autobrr once that's deployed - see issue #182).
+data: {}

--- a/services/downloads-standard/cross-seed/service.yaml
+++ b/services/downloads-standard/cross-seed/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cross-seed
+  namespace: downloads-standard
+spec:
+  type: ClusterIP
+  selector:
+    app: cross-seed
+  ports:
+  - port: 2468
+    targetPort: 2468
+    protocol: TCP
+    name: http

--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -10,6 +10,11 @@ resources:
   - prowlarr/ingress.yaml
   - prowlarr/pvc.yaml
   - prowlarr/service.yaml
+  - cross-seed/configmap.yaml
+  - cross-seed/deployment.yaml
+  - cross-seed/pvc.yaml
+  - cross-seed/secret.yaml
+  - cross-seed/service.yaml
   - radarr/deployment.yaml
   - radarr/ingress.yaml
   - radarr/postgres-databases.yaml


### PR DESCRIPTION
Closes #181.

Deploys cross-seed as a daemon under `services/downloads-standard/cross-seed/`,
wired to Flux like the rest of the downloads stack.

## How it works

- Searches via Prowlarr's torznab API (RSS every 30 min, full-catalog
  search once daily).
- Matches inject directly into qBittorrent (`action: inject`), reusing
  qBittorrent's own already-seeded data on the shared `media-standard`
  PVC rather than requiring separate `linkDirs`.
- Not exposed via Ingress — in-cluster only for now.

## Follow-up

Once autobrr (#182) is deployed, its announce webhook can call
cross-seed's HTTP API directly for near-instant matching instead of
waiting on the daily search pass.

## Before merging / after merging

Secrets aren't committed — create `cross-seed-secrets` per the README
before (or right after) this reconciles:

```sh
kubectl create secret generic cross-seed-secrets \
  --namespace downloads-standard \
  --from-literal=prowlarr-api-key='...' \
  --from-literal=qbittorrent-username='...' \
  --from-literal=qbittorrent-password='...' \
  --from-literal=cross-seed-api-key='...'
```