### PR TITLE
Sync Prowlarr's MAM session via its own dynamic-seedbox CronJob

### DIFF
--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - seerr/helmrelease.yaml
   - prowlarr/deployment.yaml
   - prowlarr/ingress.yaml
+  - prowlarr/mam-dynamic-seedbox-cronjob.yaml
   - prowlarr/pvc.yaml
   - prowlarr/service.yaml
   - radarr/deployment.yaml

--- a/services/downloads-standard/prowlarr/mam-dynamic-seedbox-cronjob.yaml
+++ b/services/downloads-standard/prowlarr/mam-dynamic-seedbox-cronjob.yaml
@@ -1,0 +1,40 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: prowlarr-mam-dynamic-seedbox
+  namespace: downloads-standard
+spec:
+  # Re-authorizes Prowlarr's egress IP with MAM's tracker in case the
+  # underlying residential connection's IP ever changes (unconfirmed
+  # whether it actually does - see qbittorrent-vpn's mam-dynamic-seedbox
+  # sidecar for the AirVPN case this pattern is copied from). Unlike that
+  # sidecar, Prowlarr doesn't sit behind gluetun, so a plain CronJob is
+  # fine here - no shared network namespace needed to get the right
+  # source IP.
+  schedule: "0 */2 * * *"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+          - name: mam-dynamic-seedbox
+            image: curlimages/curl:8.21.0
+            env:
+            - name: MAM_ID
+              valueFrom:
+                secretKeyRef:
+                  name: prowlarr-mam-dynamic-seedbox
+                  key: mam_id
+            command:
+            - sh
+            - -c
+            - |
+              curl -sS -w '\nHTTP:%{http_code}\n' -b "mam_id=${MAM_ID}" https://t.myanonamouse.net/json/dynamicSeedbox.php
+            resources:
+              requests:
+                memory: "16Mi"
+                cpu: "10m"
+              limits:
+                memory: "32Mi"
+                cpu: "50m"

--- a/services/downloads-standard/prowlarr/mam-dynamic-seedbox-secret.yaml
+++ b/services/downloads-standard/prowlarr/mam-dynamic-seedbox-secret.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: prowlarr-mam-dynamic-seedbox
+  namespace: downloads-standard
+# Dedicated MyAnonaMouse session (mam_id) for Prowlarr, created via MAM's
+# Security page with "Allow Session to set Dynamic Seedbox" = Yes. Separate
+# from qbittorrent-vpn's mam-dynamic-seedbox session (see that secret's
+# comment) because the two pods egress from different IPs - Prowlarr isn't
+# behind gluetun, it goes out on the cluster node's normal (residential)
+# IP - so sharing one session would have both sides fighting over the lock.
+data: {}


### PR DESCRIPTION
Adds a Prowlarr-side counterpart to `qbittorrent-vpn`'s MAM dynamic-seedbox sidecar, using a separate MyAnonaMouse session (`mam_id`) rather than sharing qBittorrent's.

**Why separate sessions:** Prowlarr isn't behind gluetun, so it egresses from a different IP than qBittorrent's VPN tunnel. Sharing one `mam_id` would have the two sides fighting over MAM's IP lock.

**Why a CronJob instead of a sidecar:** `qbittorrent-vpn`'s sync has to run as a sidecar in that pod specifically to ride gluetun's network namespace, so the call originates from the VPN exit IP. Prowlarr doesn't need that — it's already on whatever IP it's already on — so a plain CronJob works.

**Context:** the residential connection this cluster is on may or may not actually rotate IPs — unconfirmed either way. Given this exact failure already bit `qbittorrent-vpn` once (silent stalled downloads, MAM tracker error `Unrecognized host/PassKey`), this is cheap insurance rather than something we know is currently broken.

**Not yet done (manual, same pattern as the existing MAM secret):**
1. Create a new session in MAM's Preferences → Security page, labeled distinctly from qBittorrent's session, with "Allow Session to set Dynamic Seedbox" = Yes.
2. `kubectl create secret generic prowlarr-mam-dynamic-seedbox -n downloads-standard --from-literal=mam_id=<value>` (the committed secret is a placeholder with `data: {}`, same convention as `qbittorrent-vpn/mam-dynamic-seedbox-secret.yaml`).
3. Add MAM as an indexer in Prowlarr and sync to Sonarr/Radarr/Chaptarr's app lists.

Validated with `kubectl kustomize` + `kubectl apply --server-side --dry-run=server` against the live cluster.