### PR TITLE
Migrate bazarr config PVC to democratic-csi iSCSI

### DIFF
--- a/infrastructure/kubernetes/storage/democratic-csi/helmrelease.yaml
+++ b/infrastructure/kubernetes/storage/democratic-csi/helmrelease.yaml
@@ -51,8 +51,8 @@ spec:
           targetGroups:
             - targetGroupPortalGroup: 1
               targetGroupInitiatorGroup: 1
-              targetGroupAuthType: CHAP
-              targetGroupAuthGroup: 1
+              # CHAP unsupported. See issue #172.
+              targetGroupAuthType: None
           extentInsecureTpc: true
           extentXenCompat: false
           extentDisablePhysicalBlocksize: true

--- a/services/downloads-standard/bazarr/deployment.yaml
+++ b/services/downloads-standard/bazarr/deployment.yaml
@@ -5,11 +5,6 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
-  # RollingUpdate would briefly run two pods against bazarr-config at once.
-  # nfs-provisioner doesn't enforce ReadWriteOnce exclusivity, so concurrent
-  # writers from two nodes can corrupt state on this PVC.
-  strategy:
-    type: Recreate
   selector:
     matchLabels:
       app: bazarr
@@ -123,7 +118,7 @@ spec:
       volumes:
       - name: config
         persistentVolumeClaim:
-          claimName: bazarr-config
+          claimName: bazarr-config-iscsi
       - name: media
         persistentVolumeClaim:
           claimName: media-standard

--- a/services/downloads-standard/bazarr/pvc-config.yaml
+++ b/services/downloads-standard/bazarr/pvc-config.yaml
@@ -1,12 +1,12 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: bazarr-config
+  name: bazarr-config-iscsi
   namespace: downloads-standard
 spec:
   accessModes:
-    - ReadWriteOnce
-  storageClassName: nfs-provisioner
+    - ReadWriteOncePod
+  storageClassName: truenas-iscsi
   resources:
     requests:
       storage: 5Gi


### PR DESCRIPTION
## Why

Part of #13. `bazarr-config` was the PVC that originally motivated this
whole issue - `nfs-provisioner` doesn't enforce `ReadWriteOnce` exclusivity,
which already corrupted Bazarr's SQLite config db once. This moves it onto
`truenas-iscsi` (democratic-csi's `freenas-api-iscsi` driver), which gives
real `ReadWriteOncePod` enforcement - Kubernetes itself now rejects a
double-mount instead of relying on `strategy: Recreate`.

## What changed

- New PVC `bazarr-config-iscsi` (`truenas-iscsi`, `ReadWriteOncePod`)
  replaces `bazarr-config` (`nfs-provisioner`, `ReadWriteOnce`).
- Deployment repointed at the new PVC; `strategy: Recreate` (and its
  now-stale comment) dropped in favor of the default `RollingUpdate`.

## How this was done live

Following the procedure documented in #147's history:

1. Scaled `bazarr` to 0.
2. Created the new PVC.
3. Copied data across with a one-off `Job` (`rsync` between old and new PVC
   mounts) - config, db, cache, log, backup, restore all copied correctly.
4. Repointed the deployment, scaled back up.
5. Verified the pod came up healthy (readiness probe passing, SignalR
   connections to Sonarr/Radarr established, config data intact) before
   deleting the old PVC.

First of 9 config-PVC migrations for #13; the rest (cwa, qbittorrent-vpn,
radarr, radarr-portuguese, sabnzbd, sonarr, sonarr-anime,
sonarr-portuguese) will follow as separate PRs.