### PR TITLE
Suspend downloads-standard Kustomization during #13 PVC migration

### DIFF
--- a/clusters/eye-of-michael/flux-system/downloads-standard.yaml
+++ b/clusters/eye-of-michael/flux-system/downloads-standard.yaml
@@ -14,3 +14,10 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
+  # Suspended during #13's config-PVC migration series: several apps here
+  # get scaled to 0 and repointed at new PVCs live, out of band, one at a
+  # time across several PRs. An imperative `flux suspend` alone doesn't
+  # stick - the flux-system meta-Kustomization that applies this file would
+  # just reapply `suspend: false` from git on its own next reconcile. Revert
+  # this once all 9 PVCs are migrated.
+  suspend: true


### PR DESCRIPTION
## Why

Doing #13's 9 config-PVC migrations one at a time, live, out of band
(scale to 0, new PVC, copy data, repoint, scale up - see PR #185 for the
first one). Ran `flux suspend kustomization downloads-standard` to stop
Flux reconciling `bazarr`'s deployment back to its stale git state
mid-migration, but that alone doesn't persist: the flux-system
meta-Kustomization that applies this file would just reapply
`suspend: false` from git on its own next reconcile, resuming
reconciliation and fighting the next app's migration.

## What this does

Commits `suspend: true` on the `downloads-standard` Kustomization so it
survives across the whole migration series, not just until the next
meta-reconcile.

**This should be reverted once all 9 PVCs are migrated** (tracked as part
of #13).