### PR TITLE
Resume downloads-standard Kustomization now that #13 is complete

### DIFF
--- a/clusters/eye-of-michael/flux-system/downloads-standard.yaml
+++ b/clusters/eye-of-michael/flux-system/downloads-standard.yaml
@@ -14,10 +14,3 @@ spec:
   sourceRef:
     kind: GitRepository
     name: flux-system
-  # Suspended during #13's config-PVC migration series: several apps here
-  # get scaled to 0 and repointed at new PVCs live, out of band, one at a
-  # time across several PRs. An imperative `flux suspend` alone doesn't
-  # stick - the flux-system meta-Kustomization that applies this file would
-  # just reapply `suspend: false` from git on its own next reconcile. Revert
-  # this once all 9 PVCs are migrated.
-  suspend: true


### PR DESCRIPTION
## Why

Closes out #13's migration series. All 9 apps' config PVCs (bazarr,
calibre-web-automated, qbittorrent-vpn, radarr-standard,
radarr-portuguese, sabnzbd-standard, sonarr-standard, sonarr-anime,
sonarr-portuguese), plus cwa-library which turned out to need the same
treatment, are migrated to democratic-csi/truenas-iscsi
(ReadWriteOncePod), verified healthy, and the old nfs-provisioner PVCs
deleted.

`downloads-standard`'s Kustomization was suspended for the whole
series (#186) so Flux wouldn't fight the live scale-down/repoint steps.

## What this does

Reverts #186's `suspend: true`. Verified safe first: `kubectl kustomize
services/downloads-standard | kubectl diff -f -` against the live
cluster (post #185/#187) shows **zero drift** - resuming reconciliation
won't change anything unexpected.