### PR TITLE
Fix env var case in Chaptarr's CWA hardlink script

### DIFF
--- a/services/downloads-standard/chaptarr/README.md
+++ b/services/downloads-standard/chaptarr/README.md
@@ -26,14 +26,13 @@ their library, one hop further:
 2. Path: `/scripts/hardlink-to-cwa-ingest.sh` (from the
    `chaptarr-hardlink-script` ConfigMap).
 3. Trigger on "On Release Import" and "On Upgrade".
-4. Click "Test" once wired up, then check the pod logs
-   (`kubectl logs -n downloads-standard deploy/chaptarr`) for the script's
-   `hardlink-to-cwa-ingest:` output.
+4. Click "Test" to confirm it's wired up correctly (exits 0 without
+   touching the filesystem - Chaptarr's own "Test" doesn't actually invoke
+   custom scripts, so this only confirms the notification is saved, not
+   that the script runs. Trigger a real import to confirm end-to-end.)
 
-The script reads `$chaptarr_addedbookpaths` (pipe-separated import paths),
-modeled on Readarr's undocumented `readarr_addedbookpaths` - **this env var
-name is unverified against a running Chaptarr instance.** If step 4 logs
-"chaptarr_addedbookpaths is unset", run `env | grep -i chaptarr` from the
-Custom Script instead (temporarily swap the script's Path in Chaptarr's UI,
-or exec into the container after a live import) to find the actual name(s)
-Chaptarr passes, then update `configmap-hardlink-script.yaml` to match.
+The script reads `$Chaptarr_AddedBookPaths` (pipe-separated import paths),
+confirmed against `CustomScript.cs` in the Chaptarr source
+(`Chaptarr/chaptarr@main`) - capitalized with a `Chaptarr_` prefix, unlike
+Readarr's lowercase `readarr_addedbookpaths` this was originally modeled
+on.

--- a/services/downloads-standard/chaptarr/configmap-hardlink-script.yaml
+++ b/services/downloads-standard/chaptarr/configmap-hardlink-script.yaml
@@ -3,10 +3,7 @@
 # Chaptarr's root folder (/media/books) into CWA's ingest folder
 # (/media/books-ingest), same PVC, so CWA picks it up without a copy - same
 # shape as Radarr/Sonarr hardlinking a completed download into their own
-# library. See README.md for wiring instructions, including how to confirm
-# the exact env var name Chaptarr passes (unverified against a running
-# instance as of writing - modeled on Readarr's undocumented
-# readarr_addedbookpaths).
+# library. See README.md for wiring instructions.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,18 +19,18 @@ data:
 
     # Chaptarr fires this on "Test" from the Connect settings page too -
     # nothing to link yet, so succeed without touching the filesystem.
-    if [ "${chaptarr_eventtype:-}" = "Test" ]; then
+    if [ "${Chaptarr_EventType:-}" = "Test" ]; then
       echo "hardlink-to-cwa-ingest: Test event, nothing to do"
       exit 0
     fi
 
-    if [ -z "${chaptarr_addedbookpaths:-}" ]; then
-      echo "hardlink-to-cwa-ingest: chaptarr_addedbookpaths is unset - env var name may differ, run 'env | grep -i chaptarr' from a manual trigger to confirm" >&2
+    if [ -z "${Chaptarr_AddedBookPaths:-}" ]; then
+      echo "hardlink-to-cwa-ingest: Chaptarr_AddedBookPaths is unset - nothing to link" >&2
       exit 1
     fi
 
     IFS='|'
-    for src in $chaptarr_addedbookpaths; do
+    for src in $Chaptarr_AddedBookPaths; do
       case "$src" in
         "$ROOT_FOLDER"/*) ;;
         *)


### PR DESCRIPTION
Follow-up to #178.

## What
`hardlink-to-cwa-ingest.sh` (the Connect custom script that hardlinks Chaptarr's imports into CWA's ingest folder) checked `\$chaptarr_addedbookpaths` / `\$chaptarr_eventtype`, modeled on Readarr's lowercase env vars.

Turns out Chaptarr actually passes `Chaptarr_EventType` / `Chaptarr_AddedBookPaths` - capitalized, `Chaptarr_` prefix - confirmed by reading `CustomScript.cs` in the Chaptarr source directly. Shell env vars are case-sensitive, so the script was silently failing (`Chaptarr_AddedBookPaths is unset`) on every real import; it just never got exercised until now since indexers/download client aren't wired up yet.

## Verification
Manually exec'd into the running pod and invoked the corrected script directly with a test file - confirmed a real hardlink into `/media/books-ingest` (same inode, link count 2, not a copy). Also confirmed Chaptarr's UI "Test" button on a Custom Script notification doesn't actually invoke the script (it just echoes static schema text) - so this needs a real import to exercise, not "Test".