### PR TITLE
Stop Flux from managing cross-seed-secrets

### DIFF
--- a/services/downloads-standard/kustomization.yaml
+++ b/services/downloads-standard/kustomization.yaml
@@ -14,7 +14,6 @@ resources:
   - cross-seed/configmap.yaml
   - cross-seed/deployment.yaml
   - cross-seed/pvc.yaml
-  - cross-seed/secret.yaml
   - cross-seed/service.yaml
   - radarr/deployment.yaml
   - radarr/ingress.yaml


### PR DESCRIPTION
Fixes a bug introduced in #183: \`cross-seed/secret.yaml\` (the committed
empty \`data: {}\` placeholder) was in \`kustomization.yaml\`'s resource
list, so Flux force-applied it on every reconcile - overwriting the real
secret as soon as it was created imperatively via \`kubectl create secret\`.

This follows the existing convention already used for
\`mam-dynamic-seedbox-secret.yaml\` and the democratic-csi secret: the
file stays in the repo as documentation of what keys are expected, but
is excluded from \`kustomization.yaml\` so Flux never touches it.

**After merging**, re-run the \`kubectl create secret\` command from
\`cross-seed/README.md\` - the secret Flux just wiped needs to be
recreated once this fix is in.