### PR TITLE
Filter audiobook files out of Chaptarr's CWA hardlink script

### DIFF
--- a/services/downloads-standard/chaptarr/configmap-hardlink-script.yaml
+++ b/services/downloads-standard/chaptarr/configmap-hardlink-script.yaml
@@ -38,6 +38,16 @@ data:
           continue
           ;;
       esac
+      # CWA is a Calibre/ebook tool - it can't process audiobook formats.
+      # Chaptarr's root folder is a Mixed-type one (ebooks and audiobooks
+      # both land under /media/books), so filter out audiobook files here
+      # rather than sending them into CWA's ingest to get stuck/ignored.
+      case "$src" in
+        *.mp3|*.m4a|*.m4b|*.flac|*.ogg|*.opus|*.wav|*.aac)
+          echo "hardlink-to-cwa-ingest: skipping '$src', audiobook format" >&2
+          continue
+          ;;
+      esac
       rel=${src#"$ROOT_FOLDER"/}
       dest="$INGEST_FOLDER/$rel"
       mkdir -p "$(dirname "$dest")"


### PR DESCRIPTION
CWA is a Calibre/ebook tool and can't process audiobook files. Chaptarr's
root folder is Mixed-type (ebooks and audiobooks both land under
`/media/books`), so a book added as an audiobook was getting hardlinked
into CWA's ingest folder the same as an ebook, where it would sit ignored
or get stuck in CWA's `cwa_ingest_retry_queue`.

This adds a deny-list filter for known audiobook extensions
(mp3/m4a/m4b/flac/ogg/opus/wav/aac) before hardlinking, skipping them with
a log line instead.

Follow-up from #178/#189 - this was a known open bug, deliberately
deferred until now.