### PR TITLE
Add fsGroup to cross-seed for iSCSI volume write access

### DIFF
--- a/services/downloads-standard/cross-seed/deployment.yaml
+++ b/services/downloads-standard/cross-seed/deployment.yaml
@@ -26,6 +26,7 @@ spec:
       securityContext:
         runAsUser: 1000
         runAsGroup: 1000
+        fsGroup: 1000
       containers:
       - name: cross-seed
         image: ghcr.io/cross-seed/cross-seed:6.13.7


### PR DESCRIPTION
cross-seed's pod was crash-looping:

\`\`\`
CrossSeedError: cross-seed does not have R/W permissions on your config
directory. Use chown to set the owner to 1000:1000
\`\`\`

\`truenas-iscsi\` mounts fresh volumes root-owned. \`runAsUser\`/\`runAsGroup:
1000\` only changes what UID the process runs as - it doesn't touch the
volume's ownership. \`fsGroup: 1000\` does: it tells Kubernetes to chown
the volume on mount, the same effect PUID/PGID has for the
linuxserver.io images elsewhere in this stack.