### PR TITLE
Fix cross-seed config: excludeOlder required alongside excludeRecentSearch

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -22,7 +22,11 @@ data:
       duplicateCategories: false,
       rssCadence: "30 minutes",
       searchCadence: "1 day",
-      excludeRecentSearch: "3 days",
+      // Rolling retry window, not torrent age: skip a torrent if cross-seed
+      // searched it within the last 7 days, and stop retrying it altogether
+      // once its last search is over 30 days old (assume it's exhausted).
+      excludeRecentSearch: "7 days",
+      excludeOlder: "30 days",
       delay: 30,
       apiKey: process.env.CROSS_SEED_API_KEY,
       port: 2468,


### PR DESCRIPTION
cross-seed refused to start after the fsGroup fix (#192) landed:

\`\`\`
Configuration:
    excludeOlder and excludeRecentSearch must be defined for searching.
    excludeOlder must be 2-5x excludeRecentSearch.
\`\`\`

The original config only set \`excludeRecentSearch\`. Both options
together define a rolling retry window keyed on when cross-seed last
searched a torrent (not the torrent's own age): skip re-searching
within \`excludeRecentSearch\`, and stop retrying altogether once the
last search is older than \`excludeOlder\`.

Set to 7 days / 30 days (~4.3x, within the required 2-5x range).