### PR TITLE
Stop cross-seed querying DrunkenSlug (Usenet, not a torrent tracker)

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -13,10 +13,7 @@ data:
       // at the time this was written - re-check there if this ever needs
       // updating, since IDs aren't stable across indexer add/remove).
       // Deliberately excludes id 1 (DrunkenSlug - Usenet, cross-seed can't
-      // act on NZBs). Id 2 (Portugas) is tagged "portuguese" in Prowlarr so
-      // it's only synced to the portuguese *arr apps, not the standard
-      // ones - included here anyway since cross-seed bypasses app-sync
-      // entirely and talks to each numbered endpoint directly.
+      // act on NZBs).
       torznab: [
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/2/api?apikey=${process.env.PROWLARR_API_KEY}`, // Portugas
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/3/api?apikey=${process.env.PROWLARR_API_KEY}`, // YUSCENE

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -6,8 +6,20 @@ metadata:
 data:
   config.js: |
     module.exports = {
+      // Prowlarr has no aggregate Torznab endpoint - each numbered path is
+      // one specific indexer, same as what it syncs into Sonarr/Radarr's own
+      // indexer lists. Listed here: every indexer in Prowlarr that's both
+      // protocol=torrent and enabled (checked via Prowlarr's /api/v1/indexer
+      // at the time this was written - re-check there if this ever needs
+      // updating, since IDs aren't stable across indexer add/remove).
+      // Deliberately excludes id 1 (DrunkenSlug - Usenet, cross-seed can't
+      // act on NZBs) and id 2 (Portugas - torrent but disabled in Prowlarr).
       torznab: [
-        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/1/api?apikey=${process.env.PROWLARR_API_KEY}`,
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/3/api?apikey=${process.env.PROWLARR_API_KEY}`, // YUSCENE
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/4/api?apikey=${process.env.PROWLARR_API_KEY}`, // IPTorrents
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/5/api?apikey=${process.env.PROWLARR_API_KEY}`, // FileList.io
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/6/api?apikey=${process.env.PROWLARR_API_KEY}`, // SpeedApp.io
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/7/api?apikey=${process.env.PROWLARR_API_KEY}`, // MyAnonamouse
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -13,8 +13,12 @@ data:
       // at the time this was written - re-check there if this ever needs
       // updating, since IDs aren't stable across indexer add/remove).
       // Deliberately excludes id 1 (DrunkenSlug - Usenet, cross-seed can't
-      // act on NZBs) and id 2 (Portugas - torrent but disabled in Prowlarr).
+      // act on NZBs). Id 2 (Portugas) is tagged "portuguese" in Prowlarr so
+      // it's only synced to the portuguese *arr apps, not the standard
+      // ones - included here anyway since cross-seed bypasses app-sync
+      // entirely and talks to each numbered endpoint directly.
       torznab: [
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/2/api?apikey=${process.env.PROWLARR_API_KEY}`, // Portugas
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/3/api?apikey=${process.env.PROWLARR_API_KEY}`, // YUSCENE
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/4/api?apikey=${process.env.PROWLARR_API_KEY}`, // IPTorrents
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/5/api?apikey=${process.env.PROWLARR_API_KEY}`, // FileList.io


### PR DESCRIPTION
cross-seed's \`torznab\` config pointed at Prowlarr indexer id 1, which
was never actually verified against Prowlarr's real indexer list - just
guessed. Turns out id 1 is **DrunkenSlug, a Newznab (Usenet) indexer**,
not a torrent tracker.

This is the actual cause of the \`INVALID_CONTENTS\` snatch failures seen
on the first search run (e.g. Rooster S01, all 5 retries exhausted) -
cross-seed was downloading NZBs and trying to treat them as torrents.

Checked Prowlarr's \`/api/v1/indexer\`:

| id | name | protocol | enabled |
|----|------|----------|---------|
| 1 | DrunkenSlug | usenet | yes |
| 2 | Portugas (API) | torrent | yes |
| 3 | YUSCENE (API) | torrent | yes |
| 4 | IPTorrents | torrent | yes |
| 5 | FileList.io | torrent | yes |
| 6 | SpeedApp.io | torrent | yes |
| 7 | MyAnonamouse | torrent | yes |

Replaced the single guessed URL with one entry per enabled torrent
indexer (2, 3, 4, 5, 6, 7) - Prowlarr has no aggregate Torznab endpoint,
each numbered path is one specific indexer, same pattern Prowlarr uses
to sync indexers into Sonarr/Radarr's own lists.