### PR TITLE
Ease cross-seed's load on trackers

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -35,17 +35,11 @@ data:
       duplicateCategories: false,
       rssCadence: "30 minutes",
       searchCadence: "1 day",
-      // Rolling retry window, not torrent age: skip a torrent if cross-seed
-      // searched it within the last 30 days, and stop retrying it altogether
-      // once its last search is over 120 days old (assume it's exhausted).
-      // Wide on purpose: the daily searchCadence would otherwise re-query
-      // every unmatched candidate against every indexer daily for the whole
-      // window, which is real sustained load across every tracker.
+      // Retry window keyed on last search time, not torrent age. Wide to
+      // avoid re-querying every unmatched candidate on every daily sweep.
       excludeRecentSearch: "30 days",
       excludeOlder: "120 days",
-      // 30s between queries was too fast for IPTorrents' burst limit (saw
-      // repeated 429s mid-sweep); 90s spaces it out enough to stop tripping
-      // that without meaningfully lengthening the daily sweep.
+      // 90s avoids IPTorrents' burst limit (429s at 30s).
       delay: 90,
       apiKey: process.env.CROSS_SEED_API_KEY,
       port: 2468,

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -36,11 +36,17 @@ data:
       rssCadence: "30 minutes",
       searchCadence: "1 day",
       // Rolling retry window, not torrent age: skip a torrent if cross-seed
-      // searched it within the last 7 days, and stop retrying it altogether
-      // once its last search is over 30 days old (assume it's exhausted).
-      excludeRecentSearch: "7 days",
-      excludeOlder: "30 days",
-      delay: 30,
+      // searched it within the last 30 days, and stop retrying it altogether
+      // once its last search is over 120 days old (assume it's exhausted).
+      // Wide on purpose: the daily searchCadence would otherwise re-query
+      // every unmatched candidate against every indexer daily for the whole
+      // window, which is real sustained load across every tracker.
+      excludeRecentSearch: "30 days",
+      excludeOlder: "120 days",
+      // 30s between queries was too fast for IPTorrents' burst limit (saw
+      // repeated 429s mid-sweep); 90s spaces it out enough to stop tripping
+      // that without meaningfully lengthening the daily sweep.
+      delay: 90,
       apiKey: process.env.CROSS_SEED_API_KEY,
       port: 2468,
       host: "0.0.0.0",


### PR DESCRIPTION
Two real rate-limit problems showed up once cross-seed's indexer list
was corrected (#195) and it actually started hitting live trackers:

1. **IPTorrents 429s mid-sweep.** \`delay: 30\` (seconds between queries)
   was too fast for its burst limit - repeated \`request failed with code
   429 due to rate limiting\` during the full-catalog search, each
   forcing a multi-minute snooze. Bumped to 90s.

2. **Sustained daily load across every tracker.** With
   \`excludeRecentSearch: 7 days\` / \`excludeOlder: 30 days\`, any
   candidate that doesn't match keeps getting re-queried against every
   configured indexer on every daily sweep for a full month - not a
   one-time backfill cost, closer to a sustained ~348 queries/day
   floor. Widened to 30/120 days, closer to the shape of cross-seed's
   own docs example for sustainable long-term operation.

Also done directly via Prowlarr/Sonarr's own APIs, not part of this
diff:

- YUSCENE's Prowlarr query limit: 100/day -> **200/day**. Checked its
  actual day-by-day history first - the 100 default was based on a
  one-day spike (331 queries) caused by this session's own cross-seed
  testing, not real usage. Genuine organic baseline (Sonarr/Radarr) is
  ~21-66/day over the prior 8 days, so 200 covers that plus cross-seed's
  own ~58-query daily sweep with real margin.
- Sonarr's RSS Sync interval: 15min -> 30min, matching Radarr's
  existing 30min, roughly halving Sonarr's own indexer traffic.