### PR TITLE
Enable NETWORK_SHARE_MODE for CWA's NFS-backed ingest folder

### DIFF
--- a/services/downloads-standard/calibre-web-automated/deployment.yaml
+++ b/services/downloads-standard/calibre-web-automated/deployment.yaml
@@ -26,6 +26,14 @@ spec:
           value: "1000"
         - name: TZ
           value: "America/New_York"
+        # The ingest folder is an NFS-backed subpath (media-standard), and
+        # Chaptarr's hardlinks into it are written from a different pod/NFS
+        # client than CWA's own. Plain inotify doesn't see filesystem
+        # changes made by another NFS client, so CWA's watcher would never
+        # notice a hardlinked import without this - switches CWA to a
+        # polling-based watcher instead (issue #18).
+        - name: NETWORK_SHARE_MODE
+          value: "true"
         volumeMounts:
         - name: config
           mountPath: /config


### PR DESCRIPTION
CWA's ingest folder (`/cwa-book-ingest`) is a subpath of `media-standard`,
an NFS-backed PVC. Chaptarr's hardlink-to-cwa-ingest.sh writes into it from
a different pod (a different NFS client) than CWA's own. Plain inotify
only sees local filesystem changes - it doesn't see changes made by
another NFS client, so CWA's ingest watcher never actually fired for a
hardlinked import, regardless of restarts. This means no book has ever
made it from Chaptarr into CWA automatically since #18 - only the
hardlink step itself was previously verified, not the CWA-side pickup.

Sets `NETWORK_SHARE_MODE=true`, which switches CWA to its polling-based
watcher instead of inotify.

Confirmed via live testing: a book manually hardlinked into ingest sat
untouched through two CWA restarts under inotify, and was picked up
within seconds once this was set and polling took over.