### PR TITLE
Add daily etcd snapshot backup CronJob

### DIFF
--- a/clusters/eye-of-michael/flux-system/etcd-backup.yaml
+++ b/clusters/eye-of-michael/flux-system/etcd-backup.yaml
@@ -1,0 +1,14 @@
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: etcd-backup
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./infrastructure/kubernetes/etcd-backup
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - downloads-standard.yaml
   - immich.yaml
   - jellyfin.yaml
+  - etcd-backup.yaml

--- a/infrastructure/kubernetes/etcd-backup/README.md
+++ b/infrastructure/kubernetes/etcd-backup/README.md
@@ -9,12 +9,19 @@ failure, or losing quorum outright.
 ## Setup
 
 The `etcd-backup-talosconfig` secret is committed empty and must be populated
-manually after this namespace exists:
+manually after this namespace exists. Use a scoped `os:etcd:backup` role
+rather than the fleet's admin talosconfig - it grants only the etcd snapshot
+API call, nothing else:
 
 ```bash
+talosctl config new etcd-backup --roles os:etcd:backup --crt-ttl 87600h \
+  > /tmp/etcd-backup-talosconfig
+
 kubectl create secret generic etcd-backup-talosconfig -n etcd-backup \
-  --from-file=talosconfig=<path-to-talosconfig> \
+  --from-file=talosconfig=/tmp/etcd-backup-talosconfig \
   --dry-run=client -o yaml | kubectl apply -f -
+
+rm /tmp/etcd-backup-talosconfig
 ```
 
 ## Restore

--- a/infrastructure/kubernetes/etcd-backup/README.md
+++ b/infrastructure/kubernetes/etcd-backup/README.md
@@ -1,0 +1,30 @@
+# etcd Backup
+
+Daily `talosctl etcd snapshot` of the cluster's etcd, kept 14 days on
+TrueNAS-backed NFS storage. Etcd is already a 3-node HA quorum (livio-cp,
+nicholas-cp, razlo-cp) so a single disk failure doesn't lose cluster state on
+its own - this covers the remaining cases: a bad operation, correlated
+failure, or losing quorum outright.
+
+## Setup
+
+The `etcd-backup-talosconfig` secret is committed empty and must be populated
+manually after this namespace exists:
+
+```bash
+kubectl create secret generic etcd-backup-talosconfig -n etcd-backup \
+  --from-file=talosconfig=<path-to-talosconfig> \
+  --dry-run=client -o yaml | kubectl apply -f -
+```
+
+## Restore
+
+```bash
+talosctl bootstrap --recover-from=<snapshot>
+```
+
+## Retention
+
+14 daily snapshots - enough to survive a week-long absence plus slack to
+notice a silently failed job on return. Cleanup runs as part of the same
+CronJob (`find ... -mtime +14 -delete`), not a separate schedule.

--- a/infrastructure/kubernetes/etcd-backup/cronjob.yaml
+++ b/infrastructure/kubernetes/etcd-backup/cronjob.yaml
@@ -1,0 +1,45 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: etcd-snapshot
+  namespace: etcd-backup
+spec:
+  schedule: "0 3 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: etcd-snapshot
+              image: ghcr.io/siderolabs/talosctl:v1.13.8
+              command: ["/bin/sh", "-c"]
+              args:
+                - |
+                  set -eu
+                  talosctl --talosconfig /talos/talosconfig -n "$CP_NODE" -e "$CP_NODE" \
+                    etcd snapshot "/backup/etcd-$(date +%F).db"
+                  find /backup -name 'etcd-*.db' -mtime +14 -delete
+              env:
+                # Any of the three control-plane nodes works - etcd data is
+                # replicated across all of them, so this is just a fixed,
+                # reachable snapshot source rather than "the" source of truth.
+                - name: CP_NODE
+                  value: "10.0.10.40"
+              volumeMounts:
+                - name: talosconfig
+                  mountPath: /talos
+                  readOnly: true
+                - name: backup
+                  mountPath: /backup
+          volumes:
+            - name: talosconfig
+              secret:
+                secretName: etcd-backup-talosconfig
+            - name: backup
+              persistentVolumeClaim:
+                claimName: etcd-snapshots

--- a/infrastructure/kubernetes/etcd-backup/kustomization.yaml
+++ b/infrastructure/kubernetes/etcd-backup/kustomization.yaml
@@ -1,0 +1,9 @@
+# Flux-managed. See clusters/eye-of-michael/flux-system/etcd-backup.yaml for
+# the Kustomization CR that reconciles this path. #198.
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - secret.yaml
+  - pvc.yaml
+  - cronjob.yaml

--- a/infrastructure/kubernetes/etcd-backup/namespace.yaml
+++ b/infrastructure/kubernetes/etcd-backup/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: etcd-backup

--- a/infrastructure/kubernetes/etcd-backup/pvc.yaml
+++ b/infrastructure/kubernetes/etcd-backup/pvc.yaml
@@ -1,0 +1,15 @@
+# Sized well above the actual snapshot footprint (etcd's own data is only a
+# few GB) since this backs 14 days of daily snapshots plus headroom for etcd
+# growth over time.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: etcd-snapshots
+  namespace: etcd-backup
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: nfs-provisioner
+  resources:
+    requests:
+      storage: 20Gi

--- a/infrastructure/kubernetes/etcd-backup/secret.yaml
+++ b/infrastructure/kubernetes/etcd-backup/secret.yaml
@@ -1,0 +1,11 @@
+# Populated out-of-band, not committed - a talosconfig grants cluster admin
+# access. After this namespace exists:
+#   kubectl create secret generic etcd-backup-talosconfig -n etcd-backup \
+#     --from-file=talosconfig=<path-to-talosconfig> \
+#     --dry-run=client -o yaml | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+  name: etcd-backup-talosconfig
+  namespace: etcd-backup
+data: {}

--- a/infrastructure/kubernetes/etcd-backup/secret.yaml
+++ b/infrastructure/kubernetes/etcd-backup/secret.yaml
@@ -1,8 +1,12 @@
-# Populated out-of-band, not committed - a talosconfig grants cluster admin
-# access. After this namespace exists:
+# Populated out-of-band, not committed. Use a scoped os:etcd:backup role
+# (see README.md), not the fleet's admin talosconfig, so this Secret only
+# grants what the CronJob actually needs:
+#   talosctl config new etcd-backup --roles os:etcd:backup --crt-ttl 87600h \
+#     > /tmp/etcd-backup-talosconfig
 #   kubectl create secret generic etcd-backup-talosconfig -n etcd-backup \
-#     --from-file=talosconfig=<path-to-talosconfig> \
+#     --from-file=talosconfig=/tmp/etcd-backup-talosconfig \
 #     --dry-run=client -o yaml | kubectl apply -f -
+#   rm /tmp/etcd-backup-talosconfig
 apiVersion: v1
 kind: Secret
 metadata:


### PR DESCRIPTION
## What

A single CronJob (`infrastructure/kubernetes/etcd-backup/`) that runs
`talosctl etcd snapshot` daily against the eye-of-michael cluster's etcd,
writing to a TrueNAS NFS-backed PVC. Retains 14 daily snapshots via
in-job cleanup (`find ... -mtime +14 -delete`).

## Why

Investigating razlo/nicholas drive failures surfaced that we had no etcd
backup at all. This cluster runs a 3-node HA etcd quorum (livio-cp,
nicholas-cp, razlo-cp), so a single node's disk dying doesn't lose cluster
state on its own - but there's still no protection against a bad operation,
correlated failure, or losing quorum outright.

14-day retention: enough to survive a week-long absence (e.g. travel/camping)
plus slack to notice a silently failed job on return, without carrying a
month of near-identical snapshots for a recovery scenario that's unlikely to
need that much history.

## Setup after merge

The `etcd-backup-talosconfig` secret is committed empty (standard pattern in
this repo for secrets - see `secret.yaml` for the populate command).

## Out of scope (see #198)

- Alerting on backup job failure
- Velero / full workload+PV disaster recovery

Closes #198.

🤖 Generated with [Claude Code](https://claude.com/claude-code)