### PR TITLE
Set Recreate strategy on Deployments backed by RWOP PVCs

### DIFF
--- a/services/downloads-standard/bazarr/deployment.yaml
+++ b/services/downloads-standard/bazarr/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: bazarr

--- a/services/downloads-standard/calibre-web-automated/deployment.yaml
+++ b/services/downloads-standard/calibre-web-automated/deployment.yaml
@@ -5,6 +5,11 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config/library PVCs are ReadWriteOncePod - RollingUpdate deadlocks
+  # trying to schedule a second pod while the first still holds the mount
+  # (#200) - hit repeatedly during #18 follow-up work.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: calibre-web-automated

--- a/services/downloads-standard/qbittorrent-vpn/deployment.yaml
+++ b/services/downloads-standard/qbittorrent-vpn/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: qbittorrent-vpn

--- a/services/downloads-standard/radarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/radarr-portuguese/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: radarr-portuguese

--- a/services/downloads-standard/radarr/deployment.yaml
+++ b/services/downloads-standard/radarr/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: radarr-standard

--- a/services/downloads-standard/sabnzbd/deployment.yaml
+++ b/services/downloads-standard/sabnzbd/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sabnzbd-standard

--- a/services/downloads-standard/sonarr-anime/deployment.yaml
+++ b/services/downloads-standard/sonarr-anime/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sonarr-anime

--- a/services/downloads-standard/sonarr-portuguese/deployment.yaml
+++ b/services/downloads-standard/sonarr-portuguese/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sonarr-portuguese

--- a/services/downloads-standard/sonarr/deployment.yaml
+++ b/services/downloads-standard/sonarr/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: downloads-standard
 spec:
   replicas: 1
+  # config PVC is ReadWriteOncePod - RollingUpdate deadlocks trying to
+  # schedule a second pod while the first still holds the mount (#200).
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: sonarr-standard


### PR DESCRIPTION
Closes #200.

RollingUpdate (the default) tries to bring up a new pod before killing
the old one. Every Deployment whose config/library PVC is
`ReadWriteOncePod` deadlocks on that: the new pod can't schedule anywhere
while the old one still holds the exclusive mount, and the old one never
gets killed because the new one never becomes Ready. Hit this repeatedly
during #18 follow-up work on `calibre-web-automated`, requiring a manual
`kubectl delete pod` each time to unblock.

Sets `strategy.type: Recreate` on all 9 Deployments backed by an RWOP
PVC: bazarr, sabnzbd, radarr, radarr-portuguese, sonarr, sonarr-anime,
sonarr-portuguese, qbittorrent-vpn, calibre-web-automated. Each briefly
goes fully down during a rollout instead of deadlocking - a few seconds
of downtime on a single-user homelab service, not a meaningful cost.

**Left alone, as a judgment call:** chaptarr, prowlarr, cross-seed, and
signal-cli-rest-api. Their PVCs are plain `ReadWriteOnce`
(node-level exclusivity, not pod-level) - RollingUpdate isn't guaranteed
to deadlock there the way it is under RWOP, since the scheduler landing
both pods on the same node happens to work. It still carries the same
underlying concurrent-write risk RWOP was introduced to close off, but
that's a data-safety question rather than the scheduling deadlock this
PR fixes, so left out of scope here.