### PR TITLE
Move Grafana off SQLite to the existing CNPG Postgres cluster

### DIFF
--- a/infrastructure/kubernetes/database/postgres-cluster.yaml
+++ b/infrastructure/kubernetes/database/postgres-cluster.yaml
@@ -18,4 +18,4 @@ spec:
   inheritedMetadata:
     annotations:
       reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "jellyfin,signal-messaging,downloads-standard"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "jellyfin,signal-messaging,downloads-standard,observability"

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -124,15 +124,11 @@ spec:
         storageClassName: nfs-provisioner
         size: 10Gi
 
-      # Dashboards/users/alerting config live in the shared CNPG cluster
-      # (database/postgres-cluster.yaml), not local SQLite - see #35. That's
-      # what makes a real RollingUpdate safe here: the old pod keeps serving
-      # against the same Postgres-backed state until the new one is Ready,
-      # instead of the previous Recreate strategy's guaranteed zero-Grafana
-      # window on every deploy.
+      # Dashboards/users/alerting live in the shared CNPG cluster, not
+      # local SQLite - see #35.
       #
-      # Requires postgres-secret to already exist in this namespace
-      # (reflected from database/postgres-app - see docs/bootstrap/database.md).
+      # Requires postgres-secret in this namespace (reflected from
+      # database/postgres-app - see docs/bootstrap/database.md).
       env:
         GF_DATABASE_TYPE: postgres
         GF_DATABASE_HOST: postgres-rw.database.svc.cluster.local:5432
@@ -147,6 +143,7 @@ spec:
             name: postgres-secret
             key: password
 
+      # Safe now that state isn't a local single-writer SQLite file - see #35.
       deploymentStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -143,7 +143,8 @@ spec:
             name: postgres-secret
             key: password
 
-      # Safe now that state isn't a local single-writer SQLite file - see #35.
+      # Safe now that state is in Postgres, not a local single-writer
+      # SQLite file - see #35.
       deploymentStrategy:
         type: RollingUpdate
         rollingUpdate:

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/helmrelease.yaml
@@ -124,12 +124,34 @@ spec:
         storageClassName: nfs-provisioner
         size: 10Gi
 
-      # nfs-provisioner doesn't enforce ReadWriteOnce exclusivity, so a
-      # RollingUpdate can briefly double-mount this PVC across old and new pods.
-      # Grafana stores its own state in SQLite, which doesn't tolerate two
-      # concurrent writers - same failure mode that hit Bazarr, see #13.
+      # Dashboards/users/alerting config live in the shared CNPG cluster
+      # (database/postgres-cluster.yaml), not local SQLite - see #35. That's
+      # what makes a real RollingUpdate safe here: the old pod keeps serving
+      # against the same Postgres-backed state until the new one is Ready,
+      # instead of the previous Recreate strategy's guaranteed zero-Grafana
+      # window on every deploy.
+      #
+      # Requires postgres-secret to already exist in this namespace
+      # (reflected from database/postgres-app - see docs/bootstrap/database.md).
+      env:
+        GF_DATABASE_TYPE: postgres
+        GF_DATABASE_HOST: postgres-rw.database.svc.cluster.local:5432
+        GF_DATABASE_NAME: grafana
+      envValueFrom:
+        GF_DATABASE_USER:
+          secretKeyRef:
+            name: postgres-secret
+            key: username
+        GF_DATABASE_PASSWORD:
+          secretKeyRef:
+            name: postgres-secret
+            key: password
+
       deploymentStrategy:
-        type: Recreate
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
 
       sidecar:
         dashboards:

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/postgres-databases.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/postgres-databases.yaml
@@ -1,0 +1,10 @@
+apiVersion: postgresql.cnpg.io/v1
+kind: Database
+metadata:
+  name: grafana
+  namespace: database
+spec:
+  name: grafana
+  owner: app
+  cluster:
+    name: postgres

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/postgres-secret.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/postgres-secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-secret
+  namespace: observability
+  annotations:
+    reflector.v1.k8s.emberstack.com/reflects: "database/postgres-app"
+data: {}

--- a/infrastructure/kubernetes/observability/kustomization.yaml
+++ b/infrastructure/kubernetes/observability/kustomization.yaml
@@ -20,6 +20,8 @@ resources:
   - graphite-exporter/servicemonitor.yaml
   - kube-prometheus-stack/custom-alerts.yaml
   - kube-prometheus-stack/prometheus-targets-configmap.yaml
+  - kube-prometheus-stack/postgres-databases.yaml
+  - kube-prometheus-stack/postgres-secret.yaml
   - kube-prometheus-stack/helmrepository.yaml
   - kube-prometheus-stack/helmrelease.yaml
   - metrics-server/helmrepository.yaml


### PR DESCRIPTION
## What

Points Grafana's own metadata store (dashboards, users, alerting config)
at the shared CNPG Postgres cluster in `database`, instead of its default
embedded SQLite - metrics data itself stays in Prometheus, unaffected.

- New `grafana` database on the `postgres` cluster (owner `app`, same
  shared-role pattern every other app on this cluster uses - see #113 for
  the separate, still-open follow-up on splitting that out).
- `postgres-secret` reflected into `observability` from
  `database/postgres-app`, and `observability` added to the cluster's
  `reflection-allowed-namespaces`.
- Grafana's `GF_DATABASE_*` env vars wired to Postgres via `env`/
  `envValueFrom`, matching the pattern jellystat and the *arr apps already
  use for this same secret.
- `deploymentStrategy` switched from `Recreate` to a real `RollingUpdate`
  (`maxSurge: 1`, `maxUnavailable: 0`), now that Grafana's state isn't a
  local single-writer SQLite file nfs-provisioner could double-mount.

Closes #35.

## Why

Every Grafana upgrade/restart previously had a window with zero running
replicas - during the kube-prometheus-stack 84.5.0→88.5.4 bump
(2026-08-25), a cold node pulling the new image took 7+ minutes with no
dashboard access the whole time. Moving state to Postgres removes the
reason `Recreate` existed, so a RollingUpdate can keep the old pod serving
until the new one is verified Ready.

## Verification

- `kubectl kustomize infrastructure/kubernetes/observability` builds
  clean and renders the new Database/Secret/HelmRelease values as
  expected.
- Not yet applied to the live cluster - Grafana migrates its schema
  automatically against Postgres on first boot after this merges and
  Flux reconciles.

## Not in this PR

Per the issue, filed separately rather than bundled here:
- #37 covers the same incident's cluster-wide rollout-safety gaps
  (HelmRelease timeout, missing PodDisruptionBudgets).
