### PR TITLE
Add PSI (pressure stall) panels to Proxmox host dashboard

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/proxmox-overview.yaml
@@ -262,8 +262,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 12,
+            "w": 8,
+            "x": 0,
             "y": 10
           },
           "id": 3,
@@ -294,7 +294,7 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Host CPU Pressure %",
+          "title": "Host CPU Pressure % (some)",
           "type": "timeseries"
         },
         {
@@ -380,8 +380,8 @@ data:
           },
           "gridPos": {
             "h": 8,
-            "w": 12,
-            "x": 0,
+            "w": 8,
+            "x": 8,
             "y": 10
           },
           "id": 4,
@@ -412,7 +412,322 @@ data:
               "refId": "A"
             }
           ],
-          "title": "Host Memory Pressure %",
+          "title": "Host Memory Pressure % (some)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent",
+              "max": 100,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 8,
+            "x": 16,
+            "y": 10
+          },
+          "id": 22,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "100 * rate(node_pressure_memory_stalled_seconds_total{job=\"node-exporter\", role=\"host\"}[$__rate_interval])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Host Memory Pressure % (full)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent",
+              "max": 100,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 18
+          },
+          "id": 23,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "100 * rate(node_pressure_io_waiting_seconds_total{job=\"node-exporter\", role=\"host\"}[$__rate_interval])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Host IO Pressure % (some)",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 10,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 5
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "percent",
+              "max": 100,
+              "min": 0
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 18
+          },
+          "id": 24,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+              },
+              "editorMode": "code",
+              "expr": "100 * rate(node_pressure_io_stalled_seconds_total{job=\"node-exporter\", role=\"host\"}[$__rate_interval])",
+              "legendFormat": "{{host}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Host IO Pressure % (full)",
           "type": "timeseries"
         },
         {
@@ -421,7 +736,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 18
+            "y": 26
           },
           "id": 10,
           "panels": [],
@@ -498,7 +813,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 19
+            "y": 27
           },
           "id": 11,
           "options": {
@@ -603,7 +918,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 19
+            "y": 27
           },
           "id": 12,
           "options": {
@@ -708,7 +1023,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 27
+            "y": 35
           },
           "id": 13,
           "options": {
@@ -747,7 +1062,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 35
+            "y": 43
           },
           "id": 14,
           "panels": [],
@@ -824,7 +1139,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 44
           },
           "id": 15,
           "options": {
@@ -929,7 +1244,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 44
           },
           "id": 16,
           "options": {
@@ -1034,7 +1349,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 44
+            "y": 52
           },
           "id": 17,
           "options": {
@@ -1073,7 +1388,7 @@ data:
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 52
+            "y": 60
           },
           "id": 18,
           "panels": [],
@@ -1150,7 +1465,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 53
+            "y": 61
           },
           "id": 19,
           "options": {
@@ -1255,7 +1570,7 @@ data:
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 53
+            "y": 61
           },
           "id": 20,
           "options": {
@@ -1360,7 +1675,7 @@ data:
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 61
+            "y": 69
           },
           "id": 21,
           "options": {


### PR DESCRIPTION
## What
Adds memory-full, IO-some, and IO-full PSI panels to the "Host Pressure" row in `proxmox-overview.yaml`, alongside the existing CPU-some and memory-some panels (added in PR #60). CPU has no `full` PSI metric in the kernel, so that panel is left as-is and just relabeled `(some)` for clarity.

New layout in the Host Pressure row:
- Row 1: Host CPU Pressure % (some), Host Memory Pressure % (some), Host Memory Pressure % (full)
- Row 2: Host IO Pressure % (some), Host IO Pressure % (full)

## Why
Per #34: PSI shows when a host is actually resource-starved, not just busy — better early signal for host contention than raw utilization gauges.

## Verification
- Confirmed node_exporter's `pressure` collector is active on all three hosts (nicholas, livio, razlo) — queried Prometheus directly and got clean per-host series (deduped via the existing `role="host"` label filter) for all five underlying metrics: `node_pressure_{cpu,memory,io}_{waiting,stalled}_seconds_total`.
- New panels use `rate(..._total[$__rate_interval]) * 100` per the issue's guidance; existing CPU/memory-some panels keep their original 5m window (out of scope to change here).
- Tested against live Grafana by applying a scratch `proxmox-overview-dev` ConfigMap into the "Dev" folder (per the documented dev-ConfigMap workflow in `infrastructure/kubernetes/observability/README.md`) rather than just validating JSON syntax.

Closes #34