### PR TITLE
Document pre-reboot iSCSI quiesce step for TrueNAS

### DIFF
--- a/infrastructure/truenas/README.md
+++ b/infrastructure/truenas/README.md
@@ -18,3 +18,11 @@ chmod +x /mnt/<pool>/scripts/*.sh
 - Command: `/mnt/<pool>/scripts/send_zpool_metrics.sh`
 - Schedule: Every Minute (or as desired)
 - User: root
+
+## Before rebooting/updating TrueNAS
+Scale every Deployment backed by an iSCSI PVC to 0 first. Scale back to 1 once TrueNAS is reachable again. A reboot with an iSCSI session still open can force the volume's filesystem read-only, and it doesn't self-heal on its own. NFS-backed pods don't need this.
+
+Find the current list:
+```bash
+kubectl get pvc -A -o json | jq -r '.items[] | select(.spec.storageClassName=="truenas-iscsi") | "\(.metadata.namespace)/\(.metadata.name)"'
+```


### PR DESCRIPTION
Rebooting/updating TrueNAS while a Deployment has an iSCSI session open can force that volume's ext4 filesystem read-only. It doesn't self-heal — needs a scale-to-0/scale-to-1 (or worse, a manual iSCSI session teardown) to recover. Hit this today updating TrueNAS SCALE: bazarr and cross-seed crash-looped, qbittorrent-vpn/sonarr-portuguese/sonarr-standard/radarr-portuguese were silently sitting on read-only config volumes.

Adds a short pre-reboot checklist to infrastructure/truenas/README.md: scale iSCSI-backed Deployments to 0 before rebooting, back to 1 after. Queries PVCs by `storageClassName: truenas-iscsi` rather than hardcoding service names, since more services are moving onto iSCSI over time.