### PR TITLE
Fix x265 (no HDR/DV) score stacking that downgraded HDR releases (all *arr apps)

### DIFF
--- a/services/downloads-standard/recyclarr/configmap.yaml
+++ b/services/downloads-standard/recyclarr/configmap.yaml
@@ -26,10 +26,22 @@ data:
         custom_formats:
           - trash_ids:
               - dc98083864ea246d05a42df0d05f81cc  # x265 (HD)
-              - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
             assign_scores_to:
               - name: HD Bluray + WEB
                 score: 500
+          # Scored separately from (and lower than) "x265 (HD)" above: both
+          # used to be bundled at +500, but "x265 (no HDR/DV)" also matches
+          # every non-HDR x265 release that "x265 (HD)" matches, so the two
+          # stacked to 1000 and made a plain SDR release outrank an existing
+          # HDR10+/Dolby Vision file -- triggering an unwanted "upgrade" that
+          # downgraded picture quality (Supergirl (2026), 2026-09-05). Keeping
+          # this scored (rather than dropping it to 0) still lets an HDR
+          # release later outscore and replace an SDR file already on disk.
+          - trash_ids:
+              - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
+            assign_scores_to:
+              - name: HD Bluray + WEB
+                score: -100
           - trash_ids:
               - 2899d84dc9372de3408e6d8cc18e9666  # x264
             assign_scores_to:

--- a/services/downloads-standard/recyclarr/configmap.yaml
+++ b/services/downloads-standard/recyclarr/configmap.yaml
@@ -29,14 +29,8 @@ data:
             assign_scores_to:
               - name: HD Bluray + WEB
                 score: 500
-          # Scored separately from (and lower than) "x265 (HD)" above: both
-          # used to be bundled at +500, but "x265 (no HDR/DV)" also matches
-          # every non-HDR x265 release that "x265 (HD)" matches, so the two
-          # stacked to 1000 and made a plain SDR release outrank an existing
-          # HDR10+/Dolby Vision file -- triggering an unwanted "upgrade" that
-          # downgraded picture quality (Supergirl (2026), 2026-09-05). Keeping
-          # this scored (rather than dropping it to 0) still lets an HDR
-          # release later outscore and replace an SDR file already on disk.
+          # Scored separately from, and below, "x265 (HD)": both match SDR
+          # releases, so bundling them let SDR outrank HDR (Supergirl, 2026-09-05).
           - trash_ids:
               - 839bea857ed2c0a8e084f3cbdbd65ecb  # x265 (no HDR/DV)
             assign_scores_to:
@@ -69,10 +63,8 @@ data:
             assign_scores_to:
               - name: WEB-1080p
                 score: 500
-          # See radarr-standard above: scored separately from (and lower
-          # than) "x265 (HD)" because scores stack when both formats match
-          # the same release, and bundling them at the same score let a
-          # plain SDR release outrank an existing HDR/DV file.
+          # Same fix as radarr-standard above: scores stack, so bundling this
+          # with "x265 (HD)" let SDR outrank HDR.
           - trash_ids:
               - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
             assign_scores_to:
@@ -104,10 +96,8 @@ data:
             assign_scores_to:
               - name: "[Anime] Remux-1080p"
                 score: 500
-          # See radarr-standard above: scored separately from (and lower
-          # than) "x265 (HD)" because scores stack when both formats match
-          # the same release, and bundling them at the same score let a
-          # plain SDR release outrank an existing HDR/DV file.
+          # Same fix as radarr-standard above: scores stack, so bundling this
+          # with "x265 (HD)" let SDR outrank HDR.
           - trash_ids:
               - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
             assign_scores_to:

--- a/services/downloads-standard/recyclarr/configmap.yaml
+++ b/services/downloads-standard/recyclarr/configmap.yaml
@@ -66,10 +66,18 @@ data:
         custom_formats:
           - trash_ids:
               - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-              - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
             assign_scores_to:
               - name: WEB-1080p
                 score: 500
+          # See radarr-standard above: scored separately from (and lower
+          # than) "x265 (HD)" because scores stack when both formats match
+          # the same release, and bundling them at the same score let a
+          # plain SDR release outrank an existing HDR/DV file.
+          - trash_ids:
+              - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+            assign_scores_to:
+              - name: WEB-1080p
+                score: -100
           - trash_ids:
               - cddfb4e32db826151d97352b8e37c648  # x264
             assign_scores_to:
@@ -93,10 +101,18 @@ data:
         custom_formats:
           - trash_ids:
               - 47435ece6b99a0b477caf360e79ba0bb  # x265 (HD)
-              - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
             assign_scores_to:
               - name: "[Anime] Remux-1080p"
                 score: 500
+          # See radarr-standard above: scored separately from (and lower
+          # than) "x265 (HD)" because scores stack when both formats match
+          # the same release, and bundling them at the same score let a
+          # plain SDR release outrank an existing HDR/DV file.
+          - trash_ids:
+              - 9b64dff695c2115facf1b6ea59c9bd07  # x265 (no HDR/DV)
+            assign_scores_to:
+              - name: "[Anime] Remux-1080p"
+                score: -100
           - trash_ids:
               - cddfb4e32db826151d97352b8e37c648  # x264
             assign_scores_to:


### PR DESCRIPTION
Radarr's "HD Bluray + WEB" profile, Sonarr's "WEB-1080p" profile, and Sonarr-anime's "[Anime] Remux-1080p" profile all scored `x265 (HD)` and `x265 (no HDR/DV)` together at +500. Custom-format scores are additive: a plain SDR release matches *both* formats (1000 total), while an HDR10+/Dolby Vision release only matches `x265 (HD)` (500 total). That let each app treat a lower-quality SDR release as an "upgrade" over an existing HDR file.

Caught in the act on Radarr: it auto-grabbed an SDR release of Supergirl (2026) and replaced the existing HDR10+/Dolby Vision file before I could cancel it. Fixed live via the Radarr API immediately, then re-grabbed the original HDR10+/DV release (`...HiDt`) to restore it.

Checked Sonarr-standard's and Sonarr-anime's live profiles: both had the identical bundled scoring. Fixed live on both via their APIs. Checked history on both -- no evidence it had actually fired for TV/anime yet (sonarr-anime has no import history at all; sonarr-standard's last 1000 history entries show no matching downgrade).

Fix applied everywhere: `x265 (no HDR/DV)` scored separately at -100 (rather than merged into `x265 (HD)`'s +500, or dropped to 0/unscored). That keeps a real preference order -- HDR (500) > SDR x265 (400) > x264 (-500) -- and, unlike a tie at 0, still lets an HDR release later outscore and replace an SDR file already on disk.