### PR TITLE
Alert on Flux reconciliation failures via existing Alertmanager/ntfy path (#56)

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -122,6 +122,25 @@ spec:
               currently {{ printf "%.1f" $value }}%. Risks an OOMKill if it
               keeps climbing.
 
+    - name: custom-flux-health
+      rules:
+        # gotk_resource_info (customResourceState, see helmrelease.yaml)
+        # covers every Flux object's Ready condition - a failure here won't
+        # crash any pod, so nothing else alerts on it (#56).
+        - alert: FluxReconciliationFailing
+          expr: gotk_resource_info{ready="False"} == 1
+          for: 15m
+          labels:
+            severity: warning
+          annotations:
+            summary: "Flux {{ $labels.customresource_kind }}/{{ $labels.name }} in {{ $labels.exported_namespace }} isn't Ready."
+            description: >-
+              {{ $labels.customresource_kind }}/{{ $labels.name }} in
+              {{ $labels.exported_namespace }} has failed to reconcile for
+              at least 15 minutes. Check `flux logs` or `kubectl describe`
+              for that object - the previously-applied version is still
+              live, so nothing else will have alerted on this.
+
     - name: custom-etcd-latency
       rules:
         # Scraped via the etcd job in ADR 003's etcd addendum - see


### PR DESCRIPTION
Part of #56 - alert on Flux reconciliation failures.

## Problem
A `HelmRelease` or `Kustomization` that fails to apply doesn't crash any pod - the old version just keeps running - so pod-level alerting never sees it. Today the only way to notice is checking the `flux-cluster` Grafana dashboard or running `flux get` by hand.

## Fix
One new `PrometheusRule`: alert when `gotk_resource_info{ready="False"}` holds for 15+ minutes.

`gotk_resource_info` already exists for free - it's kube-state-metrics' `customResourceState` output, already configured in `helmrelease.yaml` and tracking every `Kustomization`/`HelmRelease`/`GitRepository`/`HelmRepository` in every namespace. Nobody was alerting on it. The rule uses `severity: warning`, so it flows through the Alertmanager route and ntfy-bridge receiver every other alert already uses - no new plumbing.

15m matches the common convention in several public Flux homelab setups alerting on this same metric (5-15m range; 15m specifically used in mmontes11/k8s-infrastructure). An earlier pass tried 30m to line up with worst-case HelmRelease retry timing (`timeout: 15m` x a retry), but that solves for "don't notify mid-retry" rather than the actual goal here - visibility into a failure even if Flux's own retry later resolves it. Alertmanager already auto-resolves the notification if that happens (`send_resolved: true` + the existing `resolved` block in ntfy-alertmanager's config).

Deliberately failure-only, not every successful reconcile - a success notification would just tell you what you already know from having merged the PR.

## Verified
- `kubectl kustomize` builds `infrastructure/kubernetes/observability` cleanly.
- `kubectl apply --server-side --dry-run=server` against the live cluster accepts the rule.
- Queried live Prometheus directly to confirm `gotk_resource_info` exists with the labels the rule/annotations use (`ready`, `customresource_kind`, `exported_namespace`), and that the expression currently matches nothing (no false positive today).

## Path not taken
First pass wired Flux's notification-controller (`Provider`/`Alert` CRs) straight to Alertmanager instead. Dropped it: Flux's own severity vocabulary (`info`/`error`) didn't match the existing route or ntfy-alertmanager's topic config, and the `Alert` CRD has no namespace wildcard - every managed namespace would need listing by hand and kept in sync. The metric-based rule needs none of that.

CI-diff, the other half of #56, is a separate decision (not implementation) - recorded in the issue comments.
