### PR TITLE
Fix Talos hostname crash on fresh installs

### DIFF
--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -71,6 +71,7 @@ qm create 10000 \
   --name talos-template \
   --memory 4096 \
   --cores 4 \
+  --cpu host \
   --net0 virtio,bridge=vmbr0 \
   --scsi0 local-zfs:0,import-from=/var/lib/vz/template/iso/talos-<talos-version>-nocloud-amd64.raw \
   --boot order=scsi0 \
@@ -81,6 +82,15 @@ qm create 10000 \
   --agent enabled=1 \
   --template
 ```
+
+**`--cpu host` matters even though Terraform's `clone` resource sets it again on
+every real fleet VM** (`cpu.type = "host"` in `vms.tf`, so production nodes are
+unaffected either way): a VM cloned straight from this template with plain
+`qm clone` - e.g. for scratch testing - silently inherits the template's own
+CPU model instead, defaulting to `kvm64` if unset here. `kvm64` boots Talos
+1.13's kernel into an immediate panic (`This program can only be run on
+AMD64 processors`) with no indication why. Set it on the template so a
+manual clone behaves the same as a Terraform-managed one.
 
 **`--machine q35` is required**, not optional, even if you don't need GPU passthrough on this particular host: PCIe passthrough (`hostpci` with `pcie=1`) only works on `q35` machine type, and this is set at template-creation time - it's not something Terraform or a later `qm set` can cleanly retrofit onto VMs already cloned from a `pc`/`i440fx` template. Missing this flag was the cause of a real passthrough failure during the `livio-w1` GPU work (silent until the VM was actually rebooted with `hostpci0` attached).
 

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -60,7 +60,6 @@ data "talos_machine_configuration" "controlplane" {
           image = local.control_plane_install_image
         }
         network = {
-          hostname = each.value.hostname
           interfaces = [{
             deviceSelector = {
               hardwareAddr = lower(each.value.mac_address)
@@ -107,6 +106,14 @@ data "talos_machine_configuration" "controlplane" {
           }
         }
       }
+    }),
+    # Talos 1.12+ deprecated machine.network.hostname in favor of this
+    # document - setting both makes config acquisition crash on a fresh
+    # install ("static hostname is already set"). See issue #159.
+    yamlencode({
+      apiVersion = "v1alpha1"
+      kind       = "HostnameConfig"
+      hostname   = each.value.hostname
     })
   ]
 }
@@ -133,8 +140,8 @@ resource "local_file" "meta_data" {
   for_each = local.control_plane_nodes
 
   content = yamlencode({
-    instance_id    = each.value.hostname
-    local_hostname = each.value.hostname
+    "instance-id"    = each.value.hostname
+    "local-hostname" = each.value.hostname
   })
   filename        = "${path.module}/iso-content/control-plane/${each.key}/meta-data"
   file_permission = "0600"
@@ -190,7 +197,6 @@ data "talos_machine_configuration" "worker" {
           image = local.worker_install_image
         }
         network = {
-          hostname = each.value.hostname
           interfaces = [{
             deviceSelector = {
               hardwareAddr = lower(each.value.mac_address)
@@ -208,6 +214,14 @@ data "talos_machine_configuration" "worker" {
           "topology.${var.cluster_name}/physical-host" = each.value.proxmox_node
         }
       }
+    }),
+    # Talos 1.12+ deprecated machine.network.hostname in favor of this
+    # document - setting both makes config acquisition crash on a fresh
+    # install ("static hostname is already set"). See issue #159.
+    yamlencode({
+      apiVersion = "v1alpha1"
+      kind       = "HostnameConfig"
+      hostname   = each.value.hostname
     })
   ]
 }
@@ -225,8 +239,8 @@ resource "local_file" "worker_meta_data" {
   for_each = local.worker_nodes
 
   content = yamlencode({
-    instance_id    = each.value.hostname
-    local_hostname = each.value.hostname
+    "instance-id"    = each.value.hostname
+    "local-hostname" = each.value.hostname
   })
   filename        = "${path.module}/iso-content/worker/${each.key}/meta-data"
   file_permission = "0600"


### PR DESCRIPTION
Closes #159

## Problem

Fresh Talos installs crash during config acquisition with `static hostname
is already set in v1alpha1 config`, on any genuinely fresh node - never
seen on nodes that already have a machine config applied, which is why this
went unnoticed until now.

Talos 1.12+ deprecated the legacy `machine.network.hostname` field in favor
of a separate `HostnameConfig` document. `cluster.tf`'s config_patches still
set the legacy field. `HostnameConfigV1Alpha1.V1Alpha1ConflictValidate`
(Talos source) rejects the config outright whenever both are present.

## Fix

- Drop `machine.network.hostname` from both the control-plane and worker
  `config_patches` in `cluster.tf`.
- Add a second config_patch document instead:
  `{apiVersion: v1alpha1, kind: HostnameConfig, hostname: <node hostname>}`.
- Fix a meta-data key typo along the way: `instance_id`/`local_hostname` ->
  `instance-id`/`local-hostname`. Talos's nocloud platform parser only reads
  the hyphenated keys, so these were silently never applied. Not strictly
  required once `HostnameConfig` is explicit, but worth correcting.
- `docs/bootstrap/talos.md`: add `--cpu host` to the template's `qm create`
  command. Unrelated to the hostname bug itself, but found while building a
  scratch VM to test the fix - a plain `qm clone` off the template
  otherwise inherits the default `kvm64` CPU model, which panics Talos
  1.13's kernel (`This program can only be run on AMD64 processors`) with
  no clue why. Terraform-cloned fleet VMs already set `cpu.type = "host"`
  explicitly (`vms.tf`), so real nodes were never affected - only manual/
  scratch clones off the template.

## Verification

Reproduced the crash and the fix on a scratch VM (cloned from
`talos-template`, hand-built equivalent machine config, not applied through
Terraform):

- With the legacy field + `HostnameConfig` both present: crash, exact error
  string from the issue.
- With the legacy field dropped but `HostnameConfig` left at the default
  `auto: stable`: boots cleanly, but Talos assigns a random `talos-xxx-xxx`
  hostname instead of the intended one.
- With the legacy field dropped and `HostnameConfig`'s `hostname:` field set
  explicitly (this PR's fix): boots cleanly, and Talos's own console status
  dashboard confirms the intended hostname was assigned
  (`HOST: test-scratch-159`).

This wasn't applied to a real cluster node in this round - only validated
against a hand-built equivalent config on a scratch VM. The config shape
matches what `cluster.tf` now generates closely enough that this is treated
as low risk, but flagging it as residual risk for the record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
