### PR TITLE
Drop guest-agent wait and template extension baking (#16)

### DIFF
--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -8,16 +8,14 @@ Talos is an immutable OS, meaning it is read-only and cannot be modified after d
 ### Who owns which extensions
 
 `infrastructure/proxmox/opentofu/cluster.tf` resolves each role's extension set into a Talos Image Factory schematic and feeds it into `machine.install.image`:
-- Control planes: `qemu-guest-agent`
-- Workers: `qemu-guest-agent` + `i915` (see `locals.tf`)
+- Control planes: `qemu-guest-agent`, `iscsi-tools`
+- Workers: `qemu-guest-agent`, `iscsi-tools`, `i915` (see `locals.tf`)
 
 `i915` is the Intel GPU driver - it's universal across all workers even though only `k8s-livio-w1` actually has a GPU passed through (see `services/jellyfin/README.md` and the GPU passthrough section below).
 
-Talos reinstalls itself to `install.image` on first boot **regardless of what the template already had**, so `install.image`/`cluster.tf` is the sole source of truth for which extensions actually end up running. That means `i915` never needs to be baked into the template itself - only `cluster.tf` needs to know about it.
+Talos reinstalls itself to `install.image` on first boot **regardless of what the template already had**, so `install.image`/`cluster.tf` is the sole source of truth for which extensions actually end up running. That means no extension - not even `qemu-guest-agent` - needs to be baked into the template itself.
 
-The **template** (Step 1 below) bakes in only `qemu-guest-agent`, and for one specific reason:
-- Terraform's `agent { enabled = true }` block (`vms.tf`) waits for the QEMU guest agent to respond before it considers a clone "up".
-- The currently-booted image (and its agent) keeps running throughout Talos's background reinstall to `install.image` - so having the agent present from the template means that wait never stalls, whatever `install.image` changes to.
+The **template** (Step 1 below) is a fully generic, stock Talos image with no extensions baked in at all. It only needs to boot and start talking to Terraform/the Talos API; `install.image` fully owns what's actually installed. This means `vms.tf`'s VM resources can't rely on the QEMU guest agent responding quickly - it isn't present until *after* Talos's own reinstall completes - so they don't have an `agent` block at all. Nothing needs agent-discovered IPs anyway: every node's static IP is already known up front (`locals.control_plane_nodes`/`worker_nodes`). See #16.
 
 If the extension set in `cluster.tf` ever changes, that takes effect fleet-wide the next time each node goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against the current template) - **no template rebuild required**.
 
@@ -25,21 +23,13 @@ If the extension set in `cluster.tf` ever changes, that takes effect fleet-wide 
 ### Step 1: Get Talos Linux Image
 Run these steps on **each** proxmox host
 
-1. Get the schematic ID for the template's extension set. The template only needs `qemu-guest-agent` (see "Who owns which extensions" above) - everything role-specific like `i915` is applied later via `cluster.tf`'s `install.image`, not baked in here:
+1. Get the schematic ID for a stock, no-extensions image. The Image Factory always needs a schematic id, even for a plain image, so resolve one with an empty extension list - the template is fully generic; `cluster.tf`'s `install.image` is the sole source of truth for which extensions actually end up running (see "Who owns which extensions" above):
 ```bash
 curl -s -X POST https://factory.talos.dev/schematics \
   -H "Content-Type: application/json" \
-  -d '{
-    "customization": {
-      "systemExtensions": {
-        "officialExtensions": [
-          "siderolabs/qemu-guest-agent"
-        ]
-      }
-    }
-  }'
+  -d '{"customization": {"systemExtensions": {"officialExtensions": []}}}'
 ```
-This returns a schematic `id` (a stable hash of the extension list - independent of Talos version). Re-run this if the template's own extension set ever changes; the id will change too.
+This returns a schematic `id`. It's stable across Talos versions as long as the (empty) extension list doesn't change, so you only need to do this once.
 
 2. Download the image (`nocloud`, not `bare-metal`, because it includes cloud-init support which Talos uses for initial configuration - `raw.xz` format):
 ```bash

--- a/infrastructure/proxmox/opentofu/cluster.tf
+++ b/infrastructure/proxmox/opentofu/cluster.tf
@@ -110,9 +110,20 @@ data "talos_machine_configuration" "controlplane" {
     # Talos 1.12+ deprecated machine.network.hostname in favor of this
     # document - setting both makes config acquisition crash on a fresh
     # install ("static hostname is already set"). See issue #159.
+    #
+    # `auto = "off"` is required alongside `hostname` - the generated base
+    # config already carries a HostnameConfig with auto = "stable", and this
+    # patch merges into that same document rather than replacing it. Without
+    # explicitly turning auto off, the merged document has both fields set
+    # and fails validation on a genuinely fresh install ("'auto' and
+    # 'hostname' cannot be set at the same time") - found validating #16's
+    # generic-template approach on a scratch node. Talos's own
+    # WithStaticHostname() helper (stdpatches.go) always pairs the two this
+    # way; PR #209 missed it.
     yamlencode({
       apiVersion = "v1alpha1"
       kind       = "HostnameConfig"
+      auto       = "off"
       hostname   = each.value.hostname
     })
   ]
@@ -218,9 +229,13 @@ data "talos_machine_configuration" "worker" {
     # Talos 1.12+ deprecated machine.network.hostname in favor of this
     # document - setting both makes config acquisition crash on a fresh
     # install ("static hostname is already set"). See issue #159.
+    #
+    # `auto = "off"` is required alongside `hostname` - see the matching
+    # comment on the control-plane config above.
     yamlencode({
       apiVersion = "v1alpha1"
       kind       = "HostnameConfig"
+      auto       = "off"
       hostname   = each.value.hostname
     })
   ]

--- a/infrastructure/proxmox/opentofu/vms.tf
+++ b/infrastructure/proxmox/opentofu/vms.tf
@@ -7,9 +7,11 @@ resource "proxmox_virtual_environment_vm" "control_plane" {
   node_name   = each.value.proxmox_node
   vm_id       = each.value.vm_id
 
-  agent {
-    enabled = true
-  }
+  # No `agent` block: this VM's IP is static and known up front (see
+  # locals.control_plane_nodes), so nothing needs the QEMU guest agent for
+  # readiness. Waiting on it would stall `tofu apply` against a generic
+  # template - Talos boots without qemu-guest-agent until it reinstalls to
+  # `install.image` (see cluster.tf), and clone-time is before that. See #16.
 
   clone {
     vm_id = each.value.template_vm_id
@@ -47,9 +49,7 @@ resource "proxmox_virtual_environment_vm" "worker" {
   node_name   = each.value.proxmox_node
   vm_id       = each.value.vm_id
 
-  agent {
-    enabled = true
-  }
+  # No `agent` block - see the control_plane resource above.
 
   clone {
     vm_id = each.value.template_vm_id


### PR DESCRIPTION
Continues #16, unblocked by #159's Talos hostname fix (merged).

## What
- `vms.tf`: removed the `agent { enabled = true }` block from both the
  control-plane and worker VM resources. It made `tofu apply` wait for
  qemu-guest-agent to respond after clone, which only worked because the
  template pre-baked that extension. A fully generic template won't have
  the agent until after Talos reinstalls to `install.image` - so the wait
  would stall. Every node's IP is static and known up front
  (`locals.control_plane_nodes`/`worker_nodes`), so nothing actually needs
  agent-discovered readiness.
- `docs/bootstrap/talos.md`: rewrote Step 1 and the "who owns which
  extensions" section - the template is now a stock, no-extensions image
  (resolved via an empty-list Image Factory schematic), with
  `cluster.tf`'s `install.image` as the sole source of truth for what
  actually gets installed.
- `cluster.tf`: fixed a second, previously-undiscovered hostname bug left
  by #159's fix (PR #209) - the `HostnameConfig` patch needs
  `auto = "off"` alongside `hostname`, or it merges into the base
  generated config's `auto = "stable"` document and fails validation
  ("'auto' and 'hostname' cannot be set at the same time") on a
  genuinely fresh install. Matches Talos's own `WithStaticHostname()`
  helper.

## Why
Two previously duplicated sources of truth (template-baked extensions vs.
`cluster.tf`'s `install.image`) collapse into one, and template
maintenance gets simpler - no schematic/extension bookkeeping at
template-build time at all.

## Validated live (#16's testing checklist)
- Destroyed the old pre-baked template on **nicholas** (confirmed safe first:
  all real VMs there are full ZFS clones, empty `origin`) and built a new,
  fully generic template (stock v1.13.8 image, empty-extension schematic;
  also fixed a missing `--cpu host` the old template had lacked).
- Cloned a throwaway scratch VM from it via an isolated OpenTofu config with
  its own standalone Talos secrets (never joined the real cluster), using
  the proposed no-`agent`-block `vms.tf` change.
- First attempt crash-looped on the `HostnameConfig` bug above (screenshot
  of the console confirmed the exact error) - fixed `cluster.tf`, rebuilt
  the scratch VM's config, and it came up cleanly: static IP + hostname
  applied correctly, kubelet healthy. (apid never came up, but that's
  expected - a lone worker with no control plane to fetch certs from, an
  artifact of the standalone test harness, not a real bug.)
- Scratch VM and its ISO fully torn down afterward; real fleet nodes on
  nicholas (`k8s-nicholas-cp`, `-w1`, `-w2`) confirmed untouched throughout.
- Also found and filed separately (#215, out of scope here): a
  `storage.cfg` entry (`razlo-etcd`) not scoped to its owning node, which
  broke VM destroy/start on nicholas via a cluster-wide storage-activation
  check - hit mid-validation, worked around, not fixed in this PR.

## Not done here
The template still needs to actually be rolled out to real fleet nodes
per #16's "next time a template is rebuilt" framing - no real node was
touched by this validation.
