### PR TITLE
Drop MyAnonamouse from cross-seed's indexer list

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -20,7 +20,6 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/4/api?apikey=${process.env.PROWLARR_API_KEY}`, // IPTorrents
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/5/api?apikey=${process.env.PROWLARR_API_KEY}`, // FileList.io
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/6/api?apikey=${process.env.PROWLARR_API_KEY}`, // SpeedApp.io
-        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/7/api?apikey=${process.env.PROWLARR_API_KEY}`, // MyAnonamouse
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,


### PR DESCRIPTION
MAM is a books/audio tracker; it can never match cross-seed's video PACKs
(it's TV/movie content, not audiobooks), and it was rate-limiting cross-seed's
RSS poll almost every 30-minute cycle for zero benefit — 429s on ~11 of the
last 14 polling cycles.

Follow-up to #197 (rate-limit tuning). Not related to the separate
directory-grouping issue also affecting search-mode match rates.

https://claude.ai/code/session_01SJjavhzntxi4hKvuRSo4id