### PR TITLE
Scope cross-seed's dataDirs to qBittorrent's actual save path

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -25,10 +25,7 @@ data:
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,
       ],
-      // Matches qBittorrent's own /media mount, so a match's save path lines
-      // up with qBittorrent's and cross-seed can inject directly into the
-      // client instead of needing separate linkDirs.
-      dataDirs: ["/media"],
+      dataDirs: ["/media/downloads/qbittorrent/completed"],
       matchMode: "safe",
       action: "inject",
       linkCategory: "cross-seed",


### PR DESCRIPTION
dataDirs was `["/media"]` — the whole shared PVC. cross-seed's directory
scan therefore also treated Sonarr/Radarr's reorganized library folders
(/media/tv, /media/movies, /media/trash) as original torrents, even though
those folders combine episodes hardlinked in from several separate torrents
after import. Searching for that synthetic combined-file grouping on
trackers can never match a real release.

Symptom: last night's search sweep found 0/63 matches, with several shows
queried twice (once per reorganized copy, e.g. both /media/tv/X and
/media/trash/X) for content that was never one release to begin with.

Fix: narrow dataDirs to qBittorrent's actual DefaultSavePath
(/media/downloads/qbittorrent/completed), so cross-seed only scans genuine
one-folder-per-torrent directories. Still under the same /media mount, so
path translation for direct client injection is unaffected.

https://claude.ai/code/session_01SJjavhzntxi4hKvuRSo4id