### PR TITLE
Add ladder self-hosted paywall bypass proxy

### DIFF
--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -14,3 +14,4 @@ resources:
   - downloads-standard.yaml
   - immich.yaml
   - jellyfin.yaml
+  - ladder.yaml

--- a/clusters/eye-of-michael/flux-system/ladder.yaml
+++ b/clusters/eye-of-michael/flux-system/ladder.yaml
@@ -1,0 +1,16 @@
+# Hand-authored, same pattern as observability.yaml/database.yaml/etc -
+# see that file's comment.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: ladder
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./services/ladder
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/services/ladder/configmap-ruleset.yaml
+++ b/services/ladder/configmap-ruleset.yaml
@@ -1,0 +1,20 @@
+# Upstream's example ruleset, kept as a starting point. Ladder's real value
+# is the community rulesets at github.com/everywall/ladder/tree/main/rulesets -
+# merge the domains that matter into this file as they're needed.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ladder-ruleset
+  namespace: ladder
+data:
+  ruleset.yaml: |
+    - domain: example.com
+      domains:
+        - www.beispiel.de
+      googleCache: true
+      useFlareSolverr: false
+      headers:
+        x-forwarded-for: none
+        referer: none
+        user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36
+        cookie: privacy=1

--- a/services/ladder/deployment.yaml
+++ b/services/ladder/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: ladder
-          image: ghcr.io/everywall/ladder:latest
+          image: ghcr.io/everywall/ladder:v0.0.23
           env:
             - name: PORT
               value: "8080"

--- a/services/ladder/deployment.yaml
+++ b/services/ladder/deployment.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ladder
+  namespace: ladder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: ladder
+  template:
+    metadata:
+      labels:
+        app: ladder
+    spec:
+      containers:
+        - name: ladder
+          image: ghcr.io/everywall/ladder:latest
+          env:
+            - name: PORT
+              value: "8080"
+            - name: RULESET
+              value: /app/ruleset.yaml
+            - name: LOG_URLS
+              value: "true"
+          ports:
+            - containerPort: 8080
+          volumeMounts:
+            - name: ruleset
+              mountPath: /app/ruleset.yaml
+              subPath: ruleset.yaml
+      volumes:
+        - name: ruleset
+          configMap:
+            name: ladder-ruleset

--- a/services/ladder/deployment.yaml
+++ b/services/ladder/deployment.yaml
@@ -25,11 +25,23 @@ spec:
               value: "true"
           ports:
             - containerPort: 8080
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
           volumeMounts:
             - name: ruleset
               mountPath: /app/ruleset.yaml
               subPath: ruleset.yaml
+            - name: tmp
+              mountPath: /tmp
       volumes:
         - name: ruleset
           configMap:
             name: ladder-ruleset
+        - name: tmp
+          emptyDir: {}

--- a/services/ladder/ingress.yaml
+++ b/services/ladder/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ladder
+  namespace: ladder
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - ladder.labmatt.com
+      secretName: ladder-tls
+  rules:
+    - host: ladder.labmatt.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ladder
+                port:
+                  number: 8080

--- a/services/ladder/kustomization.yaml
+++ b/services/ladder/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - configmap-ruleset.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/services/ladder/namespace.yaml
+++ b/services/ladder/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: ladder

--- a/services/ladder/namespace.yaml
+++ b/services/ladder/namespace.yaml
@@ -2,3 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: ladder
+  labels:
+    name: ladder
+    # Restricted, not the repo's usual default: this pod proxies arbitrary
+    # attacker/user-supplied URLs, so it gets less trust than the rest of
+    # the cluster.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/services/ladder/service.yaml
+++ b/services/ladder/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: ladder
+  namespace: ladder
+spec:
+  selector:
+    app: ladder
+  ports:
+    - port: 8080
+      targetPort: 8080


### PR DESCRIPTION
## What

Deploys [everywall/ladder](https://github.com/everywall/ladder) as a self-hosted paywall bypass proxy, exposed at `ladder.labmatt.com`.

## Why

Wanted a self-hosted alternative to 12ft.io. Ladder uses a per-domain YAML ruleset (header overrides, regex response rewriting, DOM injection) rather than one universal trick, backed by an actively maintained community ruleset repo, plus optional FlareSolverr support for Cloudflare-protected sites.

Deployed alongside `13ft` (separate PR) as a fallback pair: ladder for sites with a maintained ruleset, 13ft's generic Googlebot-spoof for anything ladder doesn't have a rule for. Neither is a silver bullet on its own since paywall bypass is inherently an arms race against publisher changes - running both covers more ground than either alone.

## Shape

Own namespace + top-level Flux Kustomization, same pattern as `jellystat`/`immich-power-tools` (plain Deployment/Service/Ingress, no Helm). Ships with upstream's example `ruleset.yaml` in a ConfigMap as a starting point - real per-site coverage comes from merging in rules from the [community rulesets](https://github.com/everywall/ladder/tree/main/rulesets) as needed.

https://claude.ai/code/session_01BrMhbyro61ABfZq4CjwAGT