### PR TITLE
Add 13ft self-hosted paywall bypass proxy

### DIFF
--- a/clusters/eye-of-michael/flux-system/13ft.yaml
+++ b/clusters/eye-of-michael/flux-system/13ft.yaml
@@ -1,0 +1,16 @@
+# Hand-authored, same pattern as observability.yaml/database.yaml/etc -
+# see that file's comment.
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: "13ft"
+  namespace: flux-system
+spec:
+  interval: 10m0s
+  path: ./services/13ft
+  prune: true
+  wait: true
+  timeout: 5m0s
+  sourceRef:
+    kind: GitRepository
+    name: flux-system

--- a/clusters/eye-of-michael/flux-system/kustomization.yaml
+++ b/clusters/eye-of-michael/flux-system/kustomization.yaml
@@ -15,3 +15,4 @@ resources:
   - immich.yaml
   - jellyfin.yaml
   - ladder.yaml
+  - 13ft.yaml

--- a/services/13ft/deployment.yaml
+++ b/services/13ft/deployment.yaml
@@ -18,3 +18,17 @@ spec:
           image: ghcr.io/wasi-master/13ft:latest
           ports:
             - containerPort: 5000
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/services/13ft/deployment.yaml
+++ b/services/13ft/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: 13ft
-          image: ghcr.io/wasi-master/13ft:latest
+          image: ghcr.io/wasi-master/13ft:0.4.1
           ports:
             - containerPort: 5000
           securityContext:

--- a/services/13ft/deployment.yaml
+++ b/services/13ft/deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "13ft"
+  namespace: "13ft"
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: 13ft
+  template:
+    metadata:
+      labels:
+        app: 13ft
+    spec:
+      containers:
+        - name: 13ft
+          image: ghcr.io/wasi-master/13ft:latest
+          ports:
+            - containerPort: 5000

--- a/services/13ft/ingress.yaml
+++ b/services/13ft/ingress.yaml
@@ -1,0 +1,25 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: "13ft"
+  namespace: "13ft"
+  annotations:
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    cert-manager.io/cluster-issuer: letsencrypt-cloudflare
+spec:
+  ingressClassName: nginx
+  tls:
+    - hosts:
+        - 13ft.labmatt.com
+      secretName: 13ft-tls
+  rules:
+    - host: 13ft.labmatt.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: "13ft"
+                port:
+                  number: 5000

--- a/services/13ft/kustomization.yaml
+++ b/services/13ft/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml
+  - deployment.yaml
+  - service.yaml
+  - ingress.yaml

--- a/services/13ft/namespace.yaml
+++ b/services/13ft/namespace.yaml
@@ -2,3 +2,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: "13ft"
+  labels:
+    name: "13ft"
+    # Restricted, not the repo's usual default: this pod proxies arbitrary
+    # attacker/user-supplied URLs, so it gets less trust than the rest of
+    # the cluster.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/audit: restricted

--- a/services/13ft/namespace.yaml
+++ b/services/13ft/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "13ft"

--- a/services/13ft/service.yaml
+++ b/services/13ft/service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "13ft"
+  namespace: "13ft"
+spec:
+  selector:
+    app: 13ft
+  ports:
+    - port: 5000
+      targetPort: 5000


### PR DESCRIPTION
## What

Deploys [wasi-master/13ft](https://github.com/wasi-master/13ft) as a self-hosted paywall bypass proxy, exposed at `13ft.labmatt.com`.

## Why

Wanted a self-hosted alternative to 12ft.io. 13ft uses one generic technique (Googlebot user-agent spoofing, with multi-source fallback) rather than per-site rules, so it needs no ongoing rule maintenance but is shallower - it fails outright on sites that check more than the UA string, or that don't special-case crawlers at all.

Deployed alongside `ladder` (separate PR) as a fallback pair: ladder for sites with a maintained per-domain ruleset, 13ft's generic spoof for anything ladder doesn't have a rule for yet. Neither is a silver bullet on its own since paywall bypass is inherently an arms race against publisher changes - running both covers more ground than either alone.

## Shape

Own namespace + top-level Flux Kustomization, same pattern as `jellystat`/`immich-power-tools` (plain Deployment/Service/Ingress, no Helm, no config needed beyond the image default).

https://claude.ai/code/session_01BrMhbyro61ABfZq4CjwAGT