### PR TITLE
Bake real extensions into the Talos template instead of relying on install.image

### DIFF
--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -7,27 +7,41 @@ Talos is an immutable OS, meaning it is read-only and cannot be modified after d
 
 ### Who owns which extensions
 
-`infrastructure/proxmox/opentofu/cluster.tf` resolves each role's extension set into a Talos Image Factory schematic and feeds it into `machine.install.image`:
+**The template must have every extension baked in at build time.** A `qm clone` copies the template's disk as-is. Talos only runs its install-to-disk step - the one that would apply `machine.install.image` below - if it doesn't yet consider the disk "installed". A cloned disk already qualifies as installed, so Talos skips that step and just boots whatever the template already had. This bit the real fleet once - see #16.
+
+`infrastructure/proxmox/opentofu/cluster.tf` still resolves each role's extension set into a schematic and feeds it into `machine.install.image`:
 - Control planes: `qemu-guest-agent`, `iscsi-tools`
 - Workers: `qemu-guest-agent`, `iscsi-tools`, `i915` (see `locals.tf`)
 
-`i915` is the Intel GPU driver - it's universal across all workers even though only `k8s-livio-w1` actually has a GPU passed through (see `services/jellyfin/README.md` and the GPU passthrough section below).
+Treat that as documentation of intent, not as something that takes effect on its own. It only matters for a genuinely fresh (non-cloned) install, or if a node is manually re-upgraded via `talosctl upgrade --image=<install.image>` later. Plain clones - which is every real fleet node - never pick it up.
 
-The **template** (Step 1 below) is a fully generic, stock Talos image with no extensions baked in at all. It only needs to boot and start talking to Terraform/the Talos API; `install.image` fully owns what's actually installed. This means `vms.tf`'s VM resources can't rely on the QEMU guest agent responding quickly - it isn't present until *after* Talos's own reinstall completes - so they don't have an `agent` block at all. Nothing needs agent-discovered IPs anyway: every node's static IP is already known up front (`locals.control_plane_nodes`/`worker_nodes`). See #16.
+Every host has one template, shared by its control plane and all its workers (see `template_vm_id` in `terraform.tfvars`). So the template must be built with the **union** of every role's extensions: `qemu-guest-agent`, `iscsi-tools`, `i915`. `i915` ends up on every node this way, including control planes - that's fine, it's just an unused driver on any node without the GPU passed through (see the GPU passthrough section below).
 
-If the extension set in `cluster.tf` ever changes, that takes effect fleet-wide the next time each node goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against the current template) - **no template rebuild required**.
+**If the extension set in `cluster.tf` ever changes, you must rebuild the template** (Steps 1-2 below) before cloning any new node from it. Nothing enforces this automatically - a stale template clones silently, with whatever extensions it happened to have. Remember to rebuild.
+
+`vms.tf`'s VM resources don't have an `agent` block. Nothing needs agent-discovered IPs - every node's static IP is already known up front (`locals.control_plane_nodes`/`worker_nodes`). See #16.
 
 ## Steps
 ### Step 1: Get Talos Linux Image
 Run these steps on **each** proxmox host
 
-1. Get the schematic ID for a stock, no-extensions image. The Image Factory always needs a schematic id, even for a plain image, so resolve one with an empty extension list - the template is fully generic; `cluster.tf`'s `install.image` is the sole source of truth for which extensions actually end up running (see "Who owns which extensions" above):
+1. Get the schematic ID for the template's extension set - the union from "Who owns which extensions" above:
 ```bash
 curl -s -X POST https://factory.talos.dev/schematics \
   -H "Content-Type: application/json" \
-  -d '{"customization": {"systemExtensions": {"officialExtensions": []}}}'
+  -d '{
+    "customization": {
+      "systemExtensions": {
+        "officialExtensions": [
+          "siderolabs/qemu-guest-agent",
+          "siderolabs/iscsi-tools",
+          "siderolabs/i915"
+        ]
+      }
+    }
+  }'
 ```
-This returns a schematic `id`. It's stable across Talos versions as long as the (empty) extension list doesn't change, so you only need to do this once.
+This returns a schematic `id`. It changes if you ever change the extension list above - re-run this and rebuild the template (Step 2) when that happens.
 
 2. Download the image (`nocloud`, not `bare-metal`, because it includes cloud-init support which Talos uses for initial configuration - `raw.xz` format):
 ```bash

--- a/docs/bootstrap/talos.md
+++ b/docs/bootstrap/talos.md
@@ -13,8 +13,6 @@ Talos is an immutable OS, meaning it is read-only and cannot be modified after d
 
 `i915` is the Intel GPU driver - it's universal across all workers even though only `k8s-livio-w1` actually has a GPU passed through (see `services/jellyfin/README.md` and the GPU passthrough section below).
 
-Talos reinstalls itself to `install.image` on first boot **regardless of what the template already had**, so `install.image`/`cluster.tf` is the sole source of truth for which extensions actually end up running. That means no extension - not even `qemu-guest-agent` - needs to be baked into the template itself.
-
 The **template** (Step 1 below) is a fully generic, stock Talos image with no extensions baked in at all. It only needs to boot and start talking to Terraform/the Talos API; `install.image` fully owns what's actually installed. This means `vms.tf`'s VM resources can't rely on the QEMU guest agent responding quickly - it isn't present until *after* Talos's own reinstall completes - so they don't have an `agent` block at all. Nothing needs agent-discovered IPs anyway: every node's static IP is already known up front (`locals.control_plane_nodes`/`worker_nodes`). See #16.
 
 If the extension set in `cluster.tf` ever changes, that takes effect fleet-wide the next time each node goes through an install cycle (`talosctl upgrade`, or a destroy/recreate against the current template) - **no template rebuild required**.

--- a/infrastructure/proxmox/opentofu/vms.tf
+++ b/infrastructure/proxmox/opentofu/vms.tf
@@ -8,10 +8,8 @@ resource "proxmox_virtual_environment_vm" "control_plane" {
   vm_id       = each.value.vm_id
 
   # No `agent` block: this VM's IP is static and known up front (see
-  # locals.control_plane_nodes), so nothing needs the QEMU guest agent for
-  # readiness. Waiting on it would stall `tofu apply` against a generic
-  # template - Talos boots without qemu-guest-agent until it reinstalls to
-  # `install.image` (see cluster.tf), and clone-time is before that. See #16.
+  # locals.control_plane_nodes). Nothing needs the QEMU guest agent for
+  # readiness. See #16.
 
   clone {
     vm_id = each.value.template_vm_id


### PR DESCRIPTION
## TL;DR

Cloned Talos nodes never actually pick up `install.image`'s extensions - Talos skips its install step on an already-installed (cloned) disk - so `razlo-w1`/`nicholas-w1` ended up missing `iscsi-tools`/all extensions. This reverts #210's "fully generic template" design and bakes the real extensions into the template at build time instead, accepting manual template rebuilds over any automated fix (all of which reintroduced the same provisioner/network-dependency risk #210 removed elsewhere).

## What changed

`docs/bootstrap/talos.md`'s "Who owns which extensions" section now describes
reality: the template must be built with the full set of extensions baked in
(`qemu-guest-agent`, `iscsi-tools`, `i915` - the union of both roles', since
one template serves a host's control plane and all its workers). Step 1's
schematic `curl` uses that real list instead of an empty one. A stale
comment in `vms.tf` repeating the old, wrong claim is also fixed.

`cluster.tf`'s extension lists and `install.image` resolution are untouched -
they stay as documentation of intent and still apply to a genuinely fresh
(non-cloned) install or a manual `talosctl upgrade`.

## Why

Issue #16 (merged via #210) made the template fully generic, on the
assumption that Talos reinstalls itself to `machine.install.image` on every
boot regardless of what the template already had. That's false for a
`qm clone`: Talos only runs its install-to-disk step if it doesn't yet
consider the disk "installed", and a cloned disk already qualifies. Every
real clone silently kept whatever extensions happened to be on its host's
template, ignoring `cluster.tf` entirely.

This broke the real fleet: `razlo-w1`'s clone was missing `iscsi-tools`
(iSCSI PVC mounts failed), and `nicholas-w1`'s clone had no extensions at
all. Both are currently powered off pending this fix. Full writeup on #16:
https://github.com/MattClarke131/project-seeds/issues/16#issuecomment-5565680946

This is a deliberate reversal of part of #210's design - not a bug fix on
top of it. An automated fix (either an upgrade-on-clone provisioner, or an
auto-rebuilt template with a drift check) was considered and rejected in
favor of this simpler, manual-discipline approach: template genericity
wasn't buying anything real once the reinstall assumption turned out to be
false, and repeated attempts to automate around it kept reintroducing the
same class of provisioner/network-dependency risk this repo has already
removed once (the guest-agent wait in #210).

## Follow-up (not in this PR)

- Rebuild the `nicholas`/`razlo` templates with the real extensions baked in,
  then destroy+reclone `nicholas-w1`/`razlo-w1` and resume the paused rollout.
- #16 stays open / gets a comment noting this reversal.

https://claude.ai/code/session_01F8VeHLScedG95Xcy5zYedB
