### PR TITLE
Pin numeric runAsUser for 13ft to fix CreateContainerConfigError

### DIFF
--- a/services/13ft/deployment.yaml
+++ b/services/13ft/deployment.yaml
@@ -22,6 +22,10 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
+            # Image's USER is a name ("thirteener"), not a numeric UID, so
+            # kubelet can't verify runAsNonRoot without an explicit UID -
+            # matches the Dockerfile's default ARG UID=1000.
+            runAsUser: 1000
             capabilities:
               drop: ["ALL"]
             seccompProfile:


### PR DESCRIPTION
## What

PR #218 fixed the Service naming, but the pod itself never came up:

\`\`\`
Error: container has runAsNonRoot and image has non-numeric user (thirteener),
cannot verify user is non-root
\`\`\`

The upstream Dockerfile does \`USER thirteener\` (a name), not a numeric UID. Kubelet can't resolve that to a UID without actually running the container, so it refuses to start when \`runAsNonRoot: true\` is set without an explicit UID.

## Fix

Added \`runAsUser: 1000\` to the container's \`securityContext\`, matching the Dockerfile's \`ARG UID=1000\` default. \`ladder\` didn't hit this because its distroless base image already declares a numeric UID.

https://claude.ai/code/session_01BrMhbyro61ABfZq4CjwAGT