### PR TITLE
Document ZFS snapshot policy for sleipnir/k8s (#100)

### DIFF
--- a/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
@@ -420,6 +420,108 @@ data:
           ],
           "title": "Disk Usage",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+          },
+          "id": 5,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "scale_truenas_dataset_k8s_used",
+              "legendFormat": "sleipnir/k8s used",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "editorMode": "code",
+              "expr": "scale_truenas_dataset_k8s_snapshot_used",
+              "legendFormat": "snapshot overhead",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "sleipnir/k8s Snapshot Overhead",
+          "type": "timeseries"
         }
       ],
       "preload": false,
@@ -436,5 +538,5 @@ data:
       "timezone": "browser",
       "title": "TrueNAS",
       "uid": "ad4w48q",
-      "version": 5
+      "version": 6
     }

--- a/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
+++ b/infrastructure/kubernetes/observability/dashboards/truenas-overview.yaml
@@ -522,6 +522,108 @@ data:
           ],
           "title": "sleipnir/k8s Snapshot Overhead",
           "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "barWidthFactor": 0.6,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "auto",
+                "showValues": false,
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "bytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 24
+          },
+          "id": 6,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.3.1",
+          "targets": [
+            {
+              "editorMode": "code",
+              "expr": "scale_truenas_dataset_k8s_iscsi_used",
+              "legendFormat": "sleipnir/k8s-iscsi used",
+              "range": true,
+              "refId": "A"
+            },
+            {
+              "editorMode": "code",
+              "expr": "scale_truenas_dataset_k8s_iscsi_snapshot_used",
+              "legendFormat": "snapshot overhead",
+              "range": true,
+              "refId": "B"
+            }
+          ],
+          "title": "sleipnir/k8s-iscsi Snapshot Overhead",
+          "type": "timeseries"
         }
       ],
       "preload": false,
@@ -538,5 +640,5 @@ data:
       "timezone": "browser",
       "title": "TrueNAS",
       "uid": "ad4w48q",
-      "version": 6
+      "version": 7
     }

--- a/infrastructure/truenas/README.md
+++ b/infrastructure/truenas/README.md
@@ -27,6 +27,19 @@ Protects against write mistakes (bad rollout, corrupted upgrade, wrong
 (see #111). Snapshots are copy-on-write, so cost is proportional to churn
 between snapshots, not dataset size - negligible at this pool's scale.
 
+**What's covered:** everything provisioned by the `nfs-provisioner`
+storage class lives under `sleipnir/k8s`, so recursive snapshots on that
+dataset catch it all - Postgres, Prometheus, Loki, Grafana, Immich's DB,
+Jellyfin's config/library-index PVC, and every other app's config PVC on
+that class.
+
+**What's NOT covered:** any volume outside `sleipnir/k8s`, most notably
+the bulk media library. `jellyfin-media` and the `*arr` apps' media PVCs
+bind to the statically-provisioned `media-standard` PV
+(`services/downloads-standard/pv-media-standard.yaml`), which points at
+NFS export `/mnt/sleipnir/media-standard` - a separate dataset entirely.
+Media files get no snapshot coverage from this policy.
+
 Data Protection > Periodic Snapshot Tasks > Add
 - Dataset: `sleipnir/k8s`
 - Recursive: yes

--- a/infrastructure/truenas/README.md
+++ b/infrastructure/truenas/README.md
@@ -18,3 +18,34 @@ chmod +x /mnt/<pool>/scripts/*.sh
 - Command: `/mnt/<pool>/scripts/send_zpool_metrics.sh`
 - Schedule: Every Minute (or as desired)
 - User: root
+
+## ZFS snapshot policy (sleipnir/k8s)
+
+Protects against write mistakes (bad rollout, corrupted upgrade, wrong
+`rm`) on the `nfs-provisioner` storage class - not against drive failure
+(RAIDZ2 already covers that) and not a substitute for off-site backup
+(see #111). Snapshots are copy-on-write, so cost is proportional to churn
+between snapshots, not dataset size - negligible at this pool's scale.
+
+Data Protection > Periodic Snapshot Tasks > Add
+- Dataset: `sleipnir/k8s`
+- Recursive: yes
+- Naming schema: `auto-%Y-%m-%d_%H-%M`
+- Schedule 1 (hourly): every hour, keep for 48 hours
+- Schedule 2 (daily): once a day, keep for 30 days
+
+Add both as separate Periodic Snapshot Tasks on the same dataset - TrueNAS
+doesn't support mixed retention within a single task.
+
+### Runbook: before a major stateful upgrade
+
+Before bumping a major version on any stateful HelmRelease (Postgres,
+Prometheus, or anything else with a PVC on `nfs-provisioner`), take a
+manual snapshot first so there's a known-good rollback point independent
+of the automatic schedule:
+
+```
+zfs snapshot -r sleipnir/k8s@pre-<component>-<version>
+```
+
+e.g. `zfs snapshot -r sleipnir/k8s@pre-prometheus-v88.5.4`

--- a/infrastructure/truenas/README.md
+++ b/infrastructure/truenas/README.md
@@ -50,15 +50,35 @@ Data Protection > Periodic Snapshot Tasks > Add
 Add both as separate Periodic Snapshot Tasks on the same dataset - TrueNAS
 doesn't support mixed retention within a single task.
 
+## ZFS snapshot policy (sleipnir/k8s-iscsi)
+
+`sleipnir/k8s-iscsi` is a sibling dataset to `sleipnir/k8s`, not a child
+of it - the `truenas-iscsi` storage class (democratic-csi, #13) provisions
+here instead of `nfs-provisioner`, so nothing above reaches it. It holds
+the `downloads-standard` config PVCs #13 migrated off `nfs-provisioner`
+for RWOP safety, plus `cwa-library-iscsi` - Calibre-Web-Automated's actual
+book library, not just its config. Same write-mistake exposure as #100
+started with, on a separate dataset, so it gets the same policy:
+
+Data Protection > Periodic Snapshot Tasks > Add
+- Dataset: `sleipnir/k8s-iscsi`
+- Recursive: yes
+- Naming schema: `auto-%Y-%m-%d_%H-%M`
+- Schedule 1 (hourly): every hour, keep for 48 hours
+- Schedule 2 (daily): once a day, keep for 30 days
+
+Same two-task-per-dataset split as above.
+
 ### Runbook: before a major stateful upgrade
 
 Before bumping a major version on any stateful HelmRelease (Postgres,
-Prometheus, or anything else with a PVC on `nfs-provisioner`), take a
-manual snapshot first so there's a known-good rollback point independent
-of the automatic schedule:
+Prometheus, or anything else with a PVC on `nfs-provisioner` or
+`truenas-iscsi`), take a manual snapshot first so there's a known-good
+rollback point independent of the automatic schedule:
 
 ```
 zfs snapshot -r sleipnir/k8s@pre-<component>-<version>
+zfs snapshot -r sleipnir/k8s-iscsi@pre-<component>-<version>
 ```
 
 e.g. `zfs snapshot -r sleipnir/k8s@pre-prometheus-v88.5.4`

--- a/infrastructure/truenas/scripts/send_zpool_metrics.sh
+++ b/infrastructure/truenas/scripts/send_zpool_metrics.sh
@@ -4,7 +4,11 @@ POOL_USED=$(zpool list -Hp -o allocated sleipnir)
 POOL_TOTAL=$(zpool list -Hp -o size sleipnir)
 DATASET_USED=$(zfs list -Hp -o used sleipnir/k8s)
 SNAPSHOT_USED=$(zfs list -t snapshot -Hp -o used -r sleipnir/k8s | awk '{sum+=$1} END{print sum+0}')
+ISCSI_DATASET_USED=$(zfs list -Hp -o used sleipnir/k8s-iscsi)
+ISCSI_SNAPSHOT_USED=$(zfs list -t snapshot -Hp -o used -r sleipnir/k8s-iscsi | awk '{sum+=$1} END{print sum+0}')
 echo "scale.truenas.zpool.used $POOL_USED $(date +%s)" | nc -w1 10.0.10.31 32003
 echo "scale.truenas.zpool.total $POOL_TOTAL $(date +%s)" | nc -w1 10.0.10.31 32003
 echo "scale.truenas.dataset.k8s.used $DATASET_USED $(date +%s)" | nc -w1 10.0.10.31 32003
 echo "scale.truenas.dataset.k8s.snapshot_used $SNAPSHOT_USED $(date +%s)" | nc -w1 10.0.10.31 32003
+echo "scale.truenas.dataset.k8s_iscsi.used $ISCSI_DATASET_USED $(date +%s)" | nc -w1 10.0.10.31 32003
+echo "scale.truenas.dataset.k8s_iscsi.snapshot_used $ISCSI_SNAPSHOT_USED $(date +%s)" | nc -w1 10.0.10.31 32003

--- a/infrastructure/truenas/scripts/send_zpool_metrics.sh
+++ b/infrastructure/truenas/scripts/send_zpool_metrics.sh
@@ -2,5 +2,9 @@
 
 POOL_USED=$(zpool list -Hp -o allocated sleipnir)
 POOL_TOTAL=$(zpool list -Hp -o size sleipnir)
+DATASET_USED=$(zfs list -Hp -o used sleipnir/k8s)
+SNAPSHOT_USED=$(zfs list -t snapshot -Hp -o used -r sleipnir/k8s | awk '{sum+=$1} END{print sum+0}')
 echo "scale.truenas.zpool.used $POOL_USED $(date +%s)" | nc -w1 10.0.10.31 32003
 echo "scale.truenas.zpool.total $POOL_TOTAL $(date +%s)" | nc -w1 10.0.10.31 32003
+echo "scale.truenas.dataset.k8s.used $DATASET_USED $(date +%s)" | nc -w1 10.0.10.31 32003
+echo "scale.truenas.dataset.k8s.snapshot_used $SNAPSHOT_USED $(date +%s)" | nc -w1 10.0.10.31 32003


### PR DESCRIPTION
## What

Adds the TrueNAS Periodic Snapshot Task settings and a pre-upgrade
runbook note to `infrastructure/truenas/README.md`, per #100.

## Why

Prometheus lost ~6 months of TSDB history when a failed HelmRelease
rollout left it corrupted and the recovery wiped its data dir. RAIDZ2
protects against drive failure but faithfully protects a bad write too
- ZFS snapshots on `sleipnir` (backing the `nfs-provisioner` storage
class) are the right tool for "protect against our own mistakes."

## What this does NOT do

No off-site copy, no Kubernetes-object awareness - this is the
narrow, in-place fix scoped to #100. The broader backup story
(off-site target, Postgres/Velero, restore testing) is #111, tackled
separately.

## Next step (manual, outside git)

The Periodic Snapshot Task itself still needs to be created in the
TrueNAS UI per the settings documented here - this PR only adds the
documentation half.

Closes #100
