### PR TITLE
Add FlareSolverr to clear NYT's DataDome challenge

### DIFF
--- a/services/ladder/configmap-ruleset.yaml
+++ b/services/ladder/configmap-ruleset.yaml
@@ -1,5 +1,6 @@
 # Curated locally, not pointed at github.com/everywall/ladder-rules (stalled).
 # NYT rule sourced from that repo's rulesets/us/nytimes-com.yaml, typo-fixed.
+#
 # useFlareSolverr is on since NYT's DataDome challenge blocks a plain fetch;
 # ladder only borrows FlareSolverr's solved cookies for its own plain request
 # (doesn't proxy its rendered page), so the fake Googlebot UA was dropped -

--- a/services/ladder/configmap-ruleset.yaml
+++ b/services/ladder/configmap-ruleset.yaml
@@ -1,18 +1,9 @@
-# Curated locally rather than pointed at github.com/everywall/ladder-rules -
-# that aggregator is stalled (real fixes sitting unmerged for months, only
-# dependabot PRs land), so rules live here where they go through this repo's
-# normal PR/CI flow instead. Sourced from that repo's rulesets/us/nytimes-com.yaml,
-# with its "ueser-agent" typo fixed (as shipped upstream, that line was a no-op -
-# the actual bypass rides on the nyt-gdpr/nyt-geo cookie trick, not the UA spoof).
-#
-# NYT's DataDome challenge blocks a plain fetch outright (confirmed by testing
-# live), so useFlareSolverr is on: ladder asks FlareSolverr to solve the
-# challenge and hands the resulting cookies to its own plain HTTP request -
-# it does NOT proxy FlareSolverr's rendered page (see handlers/proxy.go). That
-# means the fake Googlebot UA below was dropped: a solved-by-real-Chrome
-# cookie paired with a UA claiming to be Googlebot is a mismatch that's more
-# likely to get flagged than a UA-less request that just passes the visiting
-# client's own.
+# Curated locally, not pointed at github.com/everywall/ladder-rules (stalled).
+# NYT rule sourced from that repo's rulesets/us/nytimes-com.yaml, typo-fixed.
+# useFlareSolverr is on since NYT's DataDome challenge blocks a plain fetch;
+# ladder only borrows FlareSolverr's solved cookies for its own plain request
+# (doesn't proxy its rendered page), so the fake Googlebot UA was dropped -
+# it'd clash with a cookie a real browser solved.
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/services/ladder/configmap-ruleset.yaml
+++ b/services/ladder/configmap-ruleset.yaml
@@ -4,6 +4,15 @@
 # normal PR/CI flow instead. Sourced from that repo's rulesets/us/nytimes-com.yaml,
 # with its "ueser-agent" typo fixed (as shipped upstream, that line was a no-op -
 # the actual bypass rides on the nyt-gdpr/nyt-geo cookie trick, not the UA spoof).
+#
+# NYT's DataDome challenge blocks a plain fetch outright (confirmed by testing
+# live), so useFlareSolverr is on: ladder asks FlareSolverr to solve the
+# challenge and hands the resulting cookies to its own plain HTTP request -
+# it does NOT proxy FlareSolverr's rendered page (see handlers/proxy.go). That
+# means the fake Googlebot UA below was dropped: a solved-by-real-Chrome
+# cookie paired with a UA claiming to be Googlebot is a mismatch that's more
+# likely to get flagged than a UA-less request that just passes the visiting
+# client's own.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -13,8 +22,8 @@ data:
   ruleset.yaml: |
     - domains:
         - www.nytimes.com
+      useFlareSolverr: true
       headers:
-        user-agent: Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)
         cookie: nyt-a=; nyt-gdpr=0; nyt-geo=DE; nyt-privacy=1
         referer: https://www.google.com/
         content-security-policy: "default-src * 'unsafe-inline' 'unsafe-eval' data: blob:;"

--- a/services/ladder/deployment.yaml
+++ b/services/ladder/deployment.yaml
@@ -23,6 +23,8 @@ spec:
               value: /app/ruleset.yaml
             - name: LOG_URLS
               value: "true"
+            - name: FLARESOLVERR_HOST
+              value: http://flaresolverr:8191
           ports:
             - containerPort: 8080
           securityContext:

--- a/services/ladder/flaresolverr-deployment.yaml
+++ b/services/ladder/flaresolverr-deployment.yaml
@@ -25,8 +25,9 @@ spec:
             allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
             runAsNonRoot: true
-            # Image's USER is a name ("flaresolverr"), not a numeric UID - same
-            # situation as 13ft. Confirmed 1000 by running `id` in the image.
+            # Image's USER is a name ("flaresolverr"), not a numeric UID, so
+            # kubelet can't verify runAsNonRoot without one. Confirmed 1000
+            # by running `id` in the image.
             runAsUser: 1000
             capabilities:
               drop: ["ALL"]

--- a/services/ladder/flaresolverr-deployment.yaml
+++ b/services/ladder/flaresolverr-deployment.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: flaresolverr
+  namespace: ladder
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: flaresolverr
+  template:
+    metadata:
+      labels:
+        app: flaresolverr
+    spec:
+      containers:
+        - name: flaresolverr
+          image: ghcr.io/flaresolverr/flaresolverr:v3.5.0
+          env:
+            - name: LOG_LEVEL
+              value: info
+          ports:
+            - containerPort: 8191
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            # Image's USER is a name ("flaresolverr"), not a numeric UID - same
+            # situation as 13ft. Confirmed 1000 by running `id` in the image.
+            runAsUser: 1000
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: config
+              mountPath: /config
+            - name: chromium-config
+              mountPath: /app/.config
+            # Chromium's default container /dev/shm (64Mi) is too small and
+            # crashes the renderer under real page loads - give it real room.
+            - name: dshm
+              mountPath: /dev/shm
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: config
+          emptyDir: {}
+        - name: chromium-config
+          emptyDir: {}
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 512Mi

--- a/services/ladder/flaresolverr-service.yaml
+++ b/services/ladder/flaresolverr-service.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: flaresolverr
+  namespace: ladder
+spec:
+  selector:
+    app: flaresolverr
+  ports:
+    - port: 8191
+      targetPort: 8191

--- a/services/ladder/kustomization.yaml
+++ b/services/ladder/kustomization.yaml
@@ -6,3 +6,5 @@ resources:
   - deployment.yaml
   - service.yaml
   - ingress.yaml
+  - flaresolverr-deployment.yaml
+  - flaresolverr-service.yaml


### PR DESCRIPTION
## What

Adds FlareSolverr (headless-Chrome challenge solver) to ladder's namespace and wires it into the NYT rule via \`useFlareSolverr: true\`.

## Why

Even after fixing the NYT ruleset (#220), requests were still blocked - confirmed live that NYT serves a DataDome bot-challenge stub (771 bytes) before ladder's header/cookie rules ever get a chance to apply. That's a different, harder wall than simple UA checks.

Verified the fix works end-to-end before building this: tested FlareSolverr directly against the same article and got the full 468KB page back with a 200 and "Challenge not detected."

## How it actually works

ladder's FlareSolverr integration (\`handlers/proxy.go\`) only asks FlareSolverr to solve the challenge and extract cookies - it does **not** proxy FlareSolverr's rendered page. ladder then makes its own plain HTTP request using those cookies. Because of that, the NYT rule's fake Googlebot UA was dropped: pairing a UA claiming to be Googlebot with a cookie that was actually solved by real Chrome is a mismatch more likely to get flagged than just letting the visiting client's own UA through.

## Placement

Deployed inside \`ladder\`'s namespace rather than as its own top-level service - it's the only consumer today (confirmed \`13ft\` has no FlareSolverr support at all in its code), and splitting it out later if a second consumer shows up is a small, mechanical move, not a rearchitecture.

## Sizing note

FlareSolverr's image is ~270MB (bundles Chromium) vs. ladder's ~15MB - each request launches a real browser instance, so expect meaningfully more resource use than the other two services in this namespace, especially under concurrent requests.