### PR TITLE
Alert on stale TrueNAS metrics pipeline (issue #101)

### DIFF
--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -148,12 +148,12 @@ spec:
         # stopped pushing) - this is what actually caught issue #101, where
         # the metric sat at a stale value for days with nothing noticing.
         - alert: TrueNASMetricsStale
-          expr: time() - graphite_last_processed_timestamp_seconds{job="graphite-exporter"} > 300
-          for: 5m
+          expr: time() - graphite_last_processed_timestamp_seconds{job="graphite-exporter"} > 1800
+          for: 0m
           labels:
             severity: warning
           annotations:
-            summary: "sleipnir's TrueNAS metrics haven't updated in over 5 minutes."
+            summary: "sleipnir's TrueNAS metrics haven't updated in over 30 minutes."
             description: >-
               graphite-exporter last processed a sample from sleipnir's
               netdata {{ printf "%.0f" $value }}s ago. Check netdata's

--- a/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
+++ b/infrastructure/kubernetes/observability/kube-prometheus-stack/custom-alerts.yaml
@@ -141,6 +141,26 @@ spec:
               for that object - the previously-applied version is still
               live, so nothing else will have alerted on this.
 
+    - name: custom-truenas-metrics
+      rules:
+        # graphite-exporter has no scrape-target failure of its own to alert
+        # on (Prometheus sees it as `up` even when sleipnir's netdata has
+        # stopped pushing) - this is what actually caught issue #101, where
+        # the metric sat at a stale value for days with nothing noticing.
+        - alert: TrueNASMetricsStale
+          expr: time() - graphite_last_processed_timestamp_seconds{job="graphite-exporter"} > 300
+          for: 5m
+          labels:
+            severity: warning
+          annotations:
+            summary: "sleipnir's TrueNAS metrics haven't updated in over 5 minutes."
+            description: >-
+              graphite-exporter last processed a sample from sleipnir's
+              netdata {{ printf "%.0f" $value }}s ago. Check netdata's
+              exporting engine on sleipnir (`journalctl -u netdata`,
+              /etc/netdata/exporting.conf) and that graphite-exporter's pod
+              is reachable at 10.0.10.31:32003.
+
     - name: custom-etcd-latency
       rules:
         # Scraped via the etcd job in ADR 003's etcd addendum - see


### PR DESCRIPTION
## What
Adds a Prometheus alert (`TrueNASMetricsStale`) that fires when
`graphite-exporter` hasn't processed a sample from sleipnir's netdata in
over 30 minutes.

## Why
Issue #101 reported the TrueNAS metrics pipeline (netdata -> graphite-exporter
-> Prometheus) as dead - `graphite_last_processed_timestamp_seconds` had sat
at 0 for days. Investigating:

- **The pipeline is actually flowing again.** It's been live and continuous
  since 2026-09-04 19:19 UTC, coincident with the graphite-exporter pod
  restart from #9's image bump to v0.17.0. Verified directly against
  Prometheus - the metric is a few seconds old and the scrape target is
  healthy.
- **No native pull-based alternative exists on this TrueNAS version.**
  netdata's own HTTP API is disabled by TrueNAS's managed config
  (`[web] enabled = no`), and `midclt call reporting.exporters.exporter_schemas`
  shows GRAPHITE is the only exporter type the middleware supports. Graphite
  push is TrueNAS SCALE 25.10.7's only integration path, not a legacy choice
  to swap out.
- **netdata is already sending far more than the dashboard uses** - per-disk
  read/write/busy%, ARC stats, NFS server-side proc4ops/rpc counters,
  per-service CPU/IO/mem - well beyond the two zpool-total metrics
  `send_zpool_metrics.sh` adds.
- The `truenas-overview` Grafana dashboard's panel queries all resolve
  against currently-live metric names in Prometheus.

The actual gap was never the pipeline itself - it's that a silent break in
it is invisible. Prometheus scrapes graphite-exporter successfully
regardless of whether sleipnir's netdata is pushing anything, so nothing
caught this for days. This alert closes that gap.

Closes #101

https://claude.ai/code/session_01BVqVPVRiNu8wbLWgBcmP51
