### PR TITLE
Wire new torrent indexers into cross-seed

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -23,6 +23,8 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/8/api?apikey=${process.env.PROWLARR_API_KEY}`, // TorrentLeech
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/9/api?apikey=${process.env.PROWLARR_API_KEY}`, // CinemaZ
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/10/api?apikey=${process.env.PROWLARR_API_KEY}`, // Anthelion
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/11/api?apikey=${process.env.PROWLARR_API_KEY}`, // CrnaBerza
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/12/api?apikey=${process.env.PROWLARR_API_KEY}`, // DocsPedia
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -20,6 +20,7 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/4/api?apikey=${process.env.PROWLARR_API_KEY}`, // IPTorrents
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/5/api?apikey=${process.env.PROWLARR_API_KEY}`, // FileList.io
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/6/api?apikey=${process.env.PROWLARR_API_KEY}`, // SpeedApp.io
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/8/api?apikey=${process.env.PROWLARR_API_KEY}`, // TorrentLeech
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -21,6 +21,8 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/5/api?apikey=${process.env.PROWLARR_API_KEY}`, // FileList.io
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/6/api?apikey=${process.env.PROWLARR_API_KEY}`, // SpeedApp.io
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/8/api?apikey=${process.env.PROWLARR_API_KEY}`, // TorrentLeech
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/9/api?apikey=${process.env.PROWLARR_API_KEY}`, // CinemaZ
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/10/api?apikey=${process.env.PROWLARR_API_KEY}`, // Anthelion
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,


### PR DESCRIPTION
## What changed

Added five newly-added Prowlarr torrent indexers to cross-seed's Torznab
list, none tagged so none sync into any *arr app's indexer list:

- TorrentLeech (id 8)
- CinemaZ (id 9)
- Anthelion (id 10)
- CrnaBerza (id 11)
- DocsPedia (id 12)

Live Prowlarr config only (not tracked in git): tagged the `Sonarr-Anime`
application with a new `anime` tag, since it previously had no tag filter
and synced every indexer including untagged ones. It now requires that tag,
which nothing carries yet.

## Why

TorrentLeech is meant to work with cross-seed only for now (see prior
commit). The rest are newly added trackers, folded into cross-seed's list
per the existing convention: every enabled torrent indexer in Prowlarr gets
a Torznab entry here (excluding usenet).

## Note

CinemaZ has a conservative Grab Limit set on the Prowlarr side (5/day) to
stay clear of its login-endpoint throttle. cross-seed's own grabs count
against that budget alongside any manual grabs - worth watching if that
limit turns out too tight once cross-seed is actively matching against it.

https://claude.ai/code/session_01EUkqTjxqjGKBRFEHQaSH1M