### PR TITLE
Add AvistaZ to cross-seed

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -25,6 +25,7 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/10/api?apikey=${process.env.PROWLARR_API_KEY}`, // Anthelion
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/11/api?apikey=${process.env.PROWLARR_API_KEY}`, // CrnaBerza
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/12/api?apikey=${process.env.PROWLARR_API_KEY}`, // DocsPedia
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/13/api?apikey=${process.env.PROWLARR_API_KEY}`, // AvistaZ
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,


### PR DESCRIPTION
## What changed

Added AvistaZ (Prowlarr indexer id 13, torrent/enabled) to cross-seed's
Torznab list, untagged so it doesn't sync into any *arr app - same
pattern as the other recently-added trackers (TorrentLeech, CinemaZ,
Anthelion, CrnaBerza, DocsPedia).

https://claude.ai/code/session_01EUkqTjxqjGKBRFEHQaSH1M