### PR TITLE
Add ABtorrents and Redacted to cross-seed's indexer list

### DIFF
--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -28,9 +28,6 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/13/api?apikey=${process.env.PROWLARR_API_KEY}`, // AvistaZ
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/14/api?apikey=${process.env.PROWLARR_API_KEY}`, // ABtorrents
         // Redacted: API key login caps at 10 req/10s (per-user, not IP).
-        // Prowlarr's own queryLimit is set to 150/day as a volume backstop -
-        // that's a separate, coarser control and doesn't itself prevent a
-        // burst, so don't assume this line alone is safe to hit harder.
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/15/api?apikey=${process.env.PROWLARR_API_KEY}`, // Redacted
       ],
       torrentClients: [

--- a/services/downloads-standard/cross-seed/configmap.yaml
+++ b/services/downloads-standard/cross-seed/configmap.yaml
@@ -26,6 +26,12 @@ data:
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/11/api?apikey=${process.env.PROWLARR_API_KEY}`, // CrnaBerza
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/12/api?apikey=${process.env.PROWLARR_API_KEY}`, // DocsPedia
         `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/13/api?apikey=${process.env.PROWLARR_API_KEY}`, // AvistaZ
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/14/api?apikey=${process.env.PROWLARR_API_KEY}`, // ABtorrents
+        // Redacted: API key login caps at 10 req/10s (per-user, not IP).
+        // Prowlarr's own queryLimit is set to 150/day as a volume backstop -
+        // that's a separate, coarser control and doesn't itself prevent a
+        // burst, so don't assume this line alone is safe to hit harder.
+        `http://prowlarr-standard.downloads-standard.svc.cluster.local:9696/15/api?apikey=${process.env.PROWLARR_API_KEY}`, // Redacted
       ],
       torrentClients: [
         `qbittorrent:http://${process.env.QBITTORRENT_USERNAME}:${process.env.QBITTORRENT_PASSWORD}@qbittorrent-vpn.downloads-standard.svc.cluster.local:8080/`,


### PR DESCRIPTION
ABtorrents was already enabled in Prowlarr but never wired into
cross-seed's Torznab list. Redacted was just added to Prowlarr for music
cross-seeding; its API-key rate limit (10 req/10s, per-user) is noted
inline since Prowlarr's own `queryLimit` is a coarser daily volume cap,
not burst protection.

Part of the audiobook/music stack work (#193, #230).

Claude-Session: https://claude.ai/code/session_01YBtk42WC3PN62UpEFpuC1V